### PR TITLE
NMRL-164 Prevent the upgrade to fail if a corrupt analysis is found

### DIFF
--- a/bika/lims/catalog.py
+++ b/bika/lims/catalog.py
@@ -446,7 +446,6 @@ def _merge_both_catalogs(catalogs_definition, catalog_extensions):
         }
     :return: a merge of the dictionaries from above with the same format.
     """
-
     result_dict = copy.deepcopy(catalogs_definition)
     ext_cat_ids = catalog_extensions.keys()
     if ext_cat_ids:
@@ -484,11 +483,7 @@ def _merge_both_catalogs(catalogs_definition, catalog_extensions):
                     logger.error(traceback.format_exc())
             else:
                 # If catalog id is not found in the original catalog
-                # definition, definition, rise an info and create the new dict
-                logger.info(
-                    "Catalog %s doesn't exist in Bika LIMS catalog "
-                    "definitions dictionary. A new catalog definition"
-                    " might be created." % ext_cat_id)
+                # definition, definition
                 result_dict[ext_cat_id] = catalog_extensions[ext_cat_id]
     return result_dict
 

--- a/bika/lims/catalog.py
+++ b/bika/lims/catalog.py
@@ -368,27 +368,28 @@ def setup_catalogs(
         }
     :force_reindex: boolean to reindex the catalogs even if there is no need
         to do so.
-    :catalog_extensions: a list of dictionaris with more elements to add to the
+    :catalog_extensions: a dict of dictionaris with more elements to add to the
         ones defined in catalogs_definition. This variable should be used to
         add more columns in a catalog from another addon of bika.
         {
-            'types': ['ContentType', ],
-            'indexes': {
-                'getDoctorUID': 'FieldIndex',
-                ...
-            },
-            'columns': [
-                'AnotherTitle',
-                ...
-            ]
+            CATALOG_ID: {
+                'types':   ['ContentType', ...],
+                'indexes': {
+                    'UID': 'FieldIndex',
+                    ...
+                },
+                'columns': [
+                    'Title',
+                    ...
+                ]
+            }
         }
     """
     # If not given catalogs_definition, use the LIMS one
     if not catalogs_definition:
         catalogs_definition = getCatalogDefinitions()
     archetype_tool = getToolByName(portal, 'archetype_tool')
-    # Making a copy of catalogs_definition and adding the catalog extensions
-    # if required
+    # Making a copy of the merge of catalog extensions and LIMS definitions
     catalogs_definition_extended_copy = {}
     if catalog_extensions:
         catalogs_definition_extended_copy = _merge_both_catalogs(
@@ -483,7 +484,7 @@ def _merge_both_catalogs(catalogs_definition, catalog_extensions):
                     logger.error(traceback.format_exc())
             else:
                 # If catalog id is not found in the original catalog
-                # definition, definition
+                # definition, add the definition from extension
                 result_dict[ext_cat_id] = catalog_extensions[ext_cat_id]
     return result_dict
 

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -329,7 +329,14 @@ class Analysis(BaseContent):
                 return None
         catalog = getToolByName(self, "uid_catalog")
         brain = catalog(UID=service_uid)
-        obj = brain[0].getObject() if brain else None
+        obj = None
+        if len(brain) == 1:
+            obj = brain[0].getObject()
+        elif len(brain) == 0:
+            log.error("No Service found for UID %s" % service_uid)
+        else len(brain) > 1:
+            raise RuntimeError(
+                "More than one Service found for UID %s" % service_uid)
         return obj
 
     def Title(self):

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -405,7 +405,14 @@ class Analysis(BaseContent):
         """
         # Getting the service like that because otherwise gives an error
         # when rebuilding the catalogs.
-        service_uid = self.getRawService()
+        try:
+            service_uid = self.getService().UID()
+        except:
+            logger.error(traceback.format_exc())
+            logger.error(
+                "Unable to get the service of analysis %s. Using getRawService"
+                " now" % self.getId())
+            service_uid = self.getRawService()
         catalog = getToolByName(self, "uid_catalog")
         brain = catalog(UID=service_uid)
         if brain:


### PR DESCRIPTION
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1034, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade.to320, line 104, in upgrade
  Module bika.lims.catalog, line 413, in setup_catalogs
  Module bika.lims.catalog, line 690, in _cleanAndRebuildIfNeeded
  Module plone.app.discussion.patches, line 47, in patchedClearFindAndRebuild
  Module OFS.FindSupport, line 239, in ZopeFindAndApply
  Module OFS.FindSupport, line 239, in ZopeFindAndApply
  Module OFS.FindSupport, line 227, in ZopeFindAndApply
  Module plone.app.discussion.patches, line 26, in indexObject
  Module Products.Archetypes.CatalogMultiplex, line 39, in indexObject
  Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 476, in catalog_object
  Module Products.ZCatalog.Catalog, line 340, in catalogObject
  Module Products.ZCatalog.Catalog, line 284, in updateMetadata
  Module Products.ZCatalog.Catalog, line 410, in recordify
  Module bika.lims.content.analysis, line 330, in Title
  Module bika.lims.content.analysis, line 317, in getServiceUsingQuery
  Module Products.Archetypes.ClassGen, line 66, in generatedEditAccessor
AttributeError: getRaw