### PR TITLE
Added path Index to catalogs.

### DIFF
--- a/bika/lims/catalog.py
+++ b/bika/lims/catalog.py
@@ -35,6 +35,9 @@ _catalogs_definition = {
             # TODO: Can be removed?
             'id': 'FieldIndex',
             'getId': 'FieldIndex',
+            # Necessary to avoid reindexing whole catalog when we need to
+            # reindex only one object. ExtendedPathIndex also could be used.
+            'path': 'PathIndex',
             'created': 'DateIndex',
             'Creator': 'FieldIndex',
             # TODO: Can be removed? Same as id
@@ -129,6 +132,9 @@ _catalogs_definition = {
             # Minimum indexes for bika_listing
             'id': 'FieldIndex',
             'getId': 'FieldIndex',
+            # Necessary to avoid reindexing whole catalog when we need to
+            # reindex only one object. ExtendedPathIndex also could be used.
+            'path': 'PathIndex',
             'created': 'DateIndex',
             'portal_type': 'FieldIndex',
             'UID': 'FieldIndex',


### PR DESCRIPTION
@Espurna noticed that, if we don't have path index in the catalogs, when reindexing an object, all objects in the catalog will be re-indexed.