### PR TITLE
NMRL-125 adding ar without client patient

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -147,8 +147,10 @@ class AnalysisServicesView(ASV):
             # The parent folder can be a client or a batch, but we need the
             # client.  It is possible that this will be None!  This happens
             # when the AR is inside a batch, and the batch has no Client set.
-            client = self.context.aq_parent if self.context.aq_parent.portal_type == 'Client'\
-                else self.context.aq_parent.getClient()
+            client = ''
+            if not self.context.aq_parent.portal_type == "AnalysisRequestsFolder":
+                client = self.context.aq_parent if self.context.aq_parent.portal_type == 'Client'\
+                    else self.context.aq_parent.getClient()
             items = super(AnalysisServicesView, self).folderitems()
             for x, item in enumerate(items):
                 if 'obj' not in items[x]:

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -982,6 +982,13 @@ class AnalysisRequestsView(BikaListingView):
             and 'LabManager' not in self.roles \
             and 'LabClerk' not in self.roles
 
+        if self.context.portal_type == "AnalysisRequestsFolder" and \
+                (self.mtool.checkPermission(AddAnalysisRequest, self.context)):
+            self.context_actions[_('Add')] = \
+                {'url': "portal_factory/AnalysisRequest/Request new analyses/"
+                        + "ar_add?ar_count=1",
+                 'icon': '++resource++bika.lims.images/add.png'}
+
         self.editresults = -1
         self.clients = {}
         # self.user_is_preserver = 'Preserver' in self.roles

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -185,7 +185,7 @@ function AnalysisRequestAddByCol() {
         $("#singleservice").parents("[uid]").attr("uid", "new")
         $("#singleservice").parents("[keyword]").attr("keyword", "")
         $("#singleservice").parents("[title]").attr("title", "")
-        $("input[type='checkbox']").removeAttr("checked")
+        $("input[type='checkbox']").not("[name^='chb_deps_']").removeAttr("checked")
         $(".min,.max,.error").val("")
 
         // filter fields based on the selected Client

--- a/bika/lims/browser/js/bika.lims.client.js
+++ b/bika/lims/browser/js/bika.lims.client.js
@@ -38,3 +38,29 @@ function ClientEditView() {
         }
     }
 }
+/**
+* Client's overlay edit view Handler. Used by add buttons to
+* manage the behaviour of the overlay.
+*/
+function ClientOverlayHandler() {
+  var that = this;
+
+  // Needed for bika.lims.loader to register the object at runtime
+  that.load = function() {}
+
+  /**
+   * Event fired on overlay.onLoad()
+   * Hides undesired contents from inside the overlay and also
+   * loads additional javascripts still not managed by the bika.lims
+   * loader
+   */
+  that.onLoad = function(event) {
+
+      // Address widget
+      $.ajax({
+          url: 'bika_widgets/addresswidget.js',
+          dataType: 'script',
+          async: false
+      });
+  }
+}

--- a/bika/lims/browser/js/bika.lims.loader.js
+++ b/bika/lims/browser/js/bika.lims.loader.js
@@ -77,6 +77,9 @@ window.bika.lims.controllers =  {
     // Clients
     ".portaltype-client.template-base_edit":
         ['ClientEditView'],
+        
+    "div.overlay #client-base-edit":
+        ['ClientOverlayHandler'],
 
     // Client Sampling Rounds
     ".template-bika-lims-content-samplingsround.portaltype-client":

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -230,6 +230,13 @@ schema = BikaSchema.copy() + Schema((
             },
             base_query={'inactive_state': 'active'},
             showOn=True,
+            add_button={
+                    'visible': True,
+                    'url': 'clients/createObject?type_name=Client',
+                    'return_fields': ['Title'],
+                    'js_controllers': ['#client-base-edit'],
+                    'overlay_handler': 'ClientOverlayHandler',
+                }
         ),
     ),
     ReferenceField(


### PR DESCRIPTION
Requirements
There should be a very simple way to allow users to register specimen, assign it to a patient, assign a patient to a client, as well as request for analysis. The analysis request form should behave in a similar way as the case form
The requirement is to have analysis request form detached from either the client or patient. At the moment, to create an analysis you have to be either in the client or patient container. Ideally, we want one to open analysis request form, without going to patient or client. From the analysis request form the user should be able to then select or create a patient as well as select a client (following province → district → client hierarchy) both of which are mandatory. In case of missing patient information, register the sample using anonymous patient to allow the sample to be registered and rejected for lack of patient information (the functionality partially exist). The case and the analysis request forms should be maintained as is – except for changes to be made to the actual fields to meet the requirements.
New Analysis Request Add form from outside the client and case. Order of the fields:
1. Patient (search/add)
2. Patient ID (autofill from patient)
3. Referrer/Client (search/add/autofill from patient)
4. Sampling Point
5. Contact (autofill from referrer/client)
6. Sample Type
7. Sampling Date
8. AR Template
9. AR Profile
Technical approach
An “Add” button will be added in the Analysis Requests list view. Thus, the user will be able to create an Analysis Request from outside a Client or Patient view. If so, the Analysis Request Add form will display the Client and Patient fields empty, but both mandatory.