### PR TITLE
NMRL-187 Client Sample ID missing

### DIFF
--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1519,11 +1519,6 @@ schema = BikaSchema.copy() + Schema((
         widget=ComputedWidget(visible=False),
     ),
     ComputedField(
-        'ClientSampleID',
-        expression="here.getSample().getClientSampleID() if here.getSample() else ''",
-        widget=ComputedWidget(visible=False),
-    ),
-    ComputedField(
         'SamplerFullName',
         expression="here._getSamplerFullName()",
         widget=ComputedWidget(visible=False),


### PR DESCRIPTION
ClientSampleID was defined twice in the Schema: as a StringField and as a ComputedField. The latter was masking the StringField, which is the one that should be displayed in the Add AR Form.