### PR TITLE
NMRL-212 Error in worksheet's view

### DIFF
--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -377,6 +377,8 @@ class FolderView(BikaListingView):
         sampletypes = []
         qcsamples = []
         for container in pos_parent.values():
+            if not container:
+                continue
             if container.portal_type == 'AnalysisRequest':
                 sampletype = "<a href='%s'>%s</a>" % \
                            (container.getSample().getSampleType().absolute_url(),


### PR DESCRIPTION
Fix sporadical error in worksheet's folder view

```
Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module bika.lims.browser.worksheet.views.folder, line 268, in __call__
    Module bika.lims.browser.bika_listing, line 786, in __call__
    Module Products.Five.browser.pagetemplatefile, line 125, in __call__
    Module Products.Five.browser.pagetemplatefile, line 59, in __call__
    Module zope.pagetemplate.pagetemplate, line 132, in pt_render
    Module five.pt.engine, line 98, in __call__
    Module z3c.pt.pagetemplate, line 163, in render
    Module chameleon.zpt.template, line 289, in render
    Module chameleon.template, line 191, in render
    Module chameleon.template, line 171, in render
    Module c93ef0010ceee24f826472dbe982633b.py, line 724, in render
    Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 1172, in render_master
    Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 484, in render_content
    Module c93ef0010ceee24f826472dbe982633b.py, line 702, in __fill_content_core
    Module five.pt.expressions, line 161, in __call__
    Module bika.lims.browser.bika_listing, line 1257, in contents_table
    Module bika.lims.browser.bika_listing, line 1418, in __init__
    Module bika.lims.browser.worksheet.views.folder, line 428, in folderitems
    Module bika.lims.browser.bika_listing, line 854, in folderitems
    Module bika.lims.browser.bika_listing, line 1238, in _folderitems
    Module bika.lims.browser.worksheet.views.folder, line 380, in folderitem

AttributeError: 'NoneType' object has no attribute 'portal_type' - Expression: "here/main_template/macros/master" - Filename: ... /lims/browser/worksheet/views/../templates/worksheets.pt - Location: (line 4: col 21) - Source: metal:use-macro="here/main_template/macros/master" ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - Arguments: repeat: {...} (0) template: <ViewPageTemplateFile - at 0x7fa76f95a6d0> views: <ViewMapper - at 0x7fa76f95aa90> modules: <instance - at 0x7fa78da4d518> args: <tuple - at 0x7fa7989f3050> here: <ImplicitAcquisitionWrapper worksheets at 0x7fa76d14f640> user: <ImplicitAcquisitionWrapper - at 0x7fa76d1bec30> nothing: <NoneType - at 0x7ab150> translate: <function translate at 0x7fa76d107d70> container: <ImplicitAcquisitionWrapper worksheets at 0x7fa76d14f640> request: <instance - at 0x7fa767342908> wrapped_repeat: <SafeMapping - at 0x7fa76fadf368> traverse_subpath: <list - at 0x7fa76f8c1098> default: <object - at 0x7fa7989c9c40> loop: {...} (3) context: <ImplicitAcquisitionWrapper worksheets at 0x7fa76d14f640> view: <FolderView base_view at 0x7fa77555cd10> target_language: <NoneType - at 0x7ab150> root: <ImplicitAcquisitionWrapper Zope at 0x7fa780be3aa0> options: {...} (0)
```