### PR TITLE
NMRL-193 Error in CloneAR during retraction. AttributeError: setRequestID

### DIFF
--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -660,7 +660,6 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
         newar.reindexObject()
         newar.aq_parent.reindexObject()
         renameAfterCreation(newar)
-        newar.setRequestID(newar.getId())
 
         if hasattr(ar, 'setChildAnalysisRequest'):
             ar.setChildAnalysisRequest(newar)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -49,7 +49,7 @@ from bika.lims.utils import user_email
 from bika.lims import logger
 from bika.lims.browser.fields import DateTimeField
 from bika.lims.browser.widgets import SelectionWidget as BikaSelectionWidget
-
+from bika.lims import deprecated
 import sys
 
 try:
@@ -1813,6 +1813,7 @@ class AnalysisRequest(BaseFolder):
         return safe_unicode(descr).encode('utf-8')
 
     # TODO: This method should be deleted, it has the same use as getId
+    @deprecated('Flagged on 170328. Use getId() instead')
     def getRequestID(self):
         """
         Another way to return the object ID. It is used as a column and index.
@@ -1820,6 +1821,16 @@ class AnalysisRequest(BaseFolder):
         :rtype: str
         """
         return self.getId()
+
+    @deprecated(
+        'Flagged on 170328. Use setId() instead, but only as a last resort')
+    def setRequestID(self, new_id):
+        """
+        Delegates to setId() function
+        :param new_id: The new id to define
+        :type spec: str
+        """
+        self.setId(new_id)
 
     def getClient(self):
         if self.aq_parent.portal_type == 'Client':

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -61,13 +61,6 @@ except ImportError:
 
 
 schema = BikaSchema.copy() + Schema((
-    # The ID assigned to the client's request by the lab
-    ComputedField(
-        'RequestID',
-        searchable=True,
-        expression="here.getId()",
-        widget=ComputedWidget(visible=False),
-    ),
     ReferenceField(
         'Contact',
         required=1,
@@ -1818,6 +1811,15 @@ class AnalysisRequest(BaseFolder):
         """ Return searchable data as Description """
         descr = " ".join((self.getId(), self.aq_parent.Title()))
         return safe_unicode(descr).encode('utf-8')
+
+    # TODO: This method should be deleted, it has the same use as getId
+    def getRequestID(self):
+        """
+        Another way to return the object ID. It is used as a column and index.
+        :returns: The object ID
+        :rtype: str
+        """
+        return self.getId()
 
     def getClient(self):
         if self.aq_parent.portal_type == 'Client':

--- a/bika/lims/jsonapi/create.py
+++ b/bika/lims/jsonapi/create.py
@@ -368,7 +368,6 @@ class Create(object):
         brains = resolve_request_lookup(context, request, 'Services')
         service_uids = [p.UID for p in brains]
         new_analyses = ar.setAnalyses(service_uids, specs=specs)
-        ar.setRequestID(ar.getId())
         ar.reindexObject()
         event.notify(ObjectInitializedEvent(ar))
         ar.at_post_create_script()


### PR DESCRIPTION
Delete `setRequestId` and move `RequestId` to a function
```
AttributeError: setRequestID
(3 additional frame(s) were not displayed)
...
  File "home/lims/Plone/zeocluster/src/bika.health/bika/health/browser/analysisrequest/workflow.py", line 20, in __call__
    _AnalysisRequestWorkflowAction.__call__(self)
  File "home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/analysisrequest/workflow.py", line 57, in __call__
    method()
  File "home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/analysisrequest/workflow.py", line 498, in workflow_action_retract_ar
    newar = self.cloneAR(ar)
  File "home/lims/Plone/zeocluster/src/bika.health/bika/health/browser/analysisrequest/workflow.py", line 111, in cloneAR
    newar = _AnalysisRequestWorkflowAction.cloneAR(self, ar)
  File "home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/analysisrequest/workflow.py", line 664, in cloneAR
    newar.setRequestID(newar.getId())

1489751887.130.977907528985 http://<ip>/clients/client-762/CPHBP17-00700-R01/workflow_action
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.workflow, line 20, in __call__
  Module bika.lims.browser.analysisrequest.workflow, line 57, in __call__
  Module bika.lims.browser.analysisrequest.workflow, line 498, in workflow_action_retract_ar
  Module bika.health.browser.analysisrequest.workflow, line 111, in cloneAR
  Module bika.lims.browser.analysisrequest.workflow, line 664, in cloneAR
AttributeError: setRequestID
```