### PR TITLE
NMRL-170/ Department filtering 'select all' bug

### DIFF
--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -429,7 +429,7 @@ function SiteView() {
             }
             setCookie(cookiename, deps.toString());
           }
-          location.reload();
+          window.location.reload(true);
         });
 
         $('#admin_dep_filter_enabled').change(function() {
@@ -441,10 +441,10 @@ function SiteView() {
                 });
                 setCookie(cookiename, deps);
                 setCookie('dep_filter_disabled','true');
-                location.reload();
+                window.location.reload(true);
               }else{
                 setCookie('dep_filter_disabled','false');
-                location.reload();
+                window.location.reload(true);
               }
             });
           loadFilterByDepartmentCookie();


### PR DESCRIPTION
'Select all' functionality wasn't working on Firefox.
Added 'full page refresh' instead of just reloading the page, and it works now.