### PR TITLE
NMRL-233 Analysis Request Add. IndexError: 0

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -243,14 +243,13 @@ class AnalysisRequestAddView(AnalysisRequestViewView):
         if not copy_from:
             return json.dumps(specs)
         uids = copy_from.split(",")
-        n = 0
-        import pdb; pdb.set_trace()
         proxies = self.analysisrequest_catalog(UID=uids)
         if not proxies:
             logger.warning(
                 'No object found for UIDs {0} while copying specs'
                 .format(copy_from))
             return json.dumps(specs)
+        n = 0
         for proxie in proxies:
             res_range = proxie.getObject().getResultsRange()
             new_rr = []

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -241,19 +241,25 @@ class AnalysisRequestAddView(AnalysisRequestViewView):
         specs = {}
         copy_from = self.request.get('copy_from', "")
         if not copy_from:
-            return {}
+            return json.dumps(specs)
         uids = copy_from.split(",")
         n = 0
-        for uid in uids:
-            proxies = self.analysisrequest_catalog(UID=uid)
-            rr = proxies[0].getObject().getResultsRange() if proxies else []
+        import pdb; pdb.set_trace()
+        proxies = self.analysisrequest_catalog(UID=uids)
+        if not proxies:
+            logger.warning(
+                'No object found for UIDs {0} while copying specs'
+                .format(copy_from))
+            return json.dumps(specs)
+        for proxie in proxies:
+            res_range = proxie.getObject().getResultsRange()
             new_rr = []
-            for i, r in enumerate(rr):
+            for i, rr in enumerate(res_range):
                 s_uid = self.bika_setup_catalog(
                     portal_type='AnalysisService',
-                    getKeyword=r['keyword'])[0].UID
-                r['uid'] = s_uid
-                new_rr.append(r)
+                    getKeyword=rr['keyword'])[0].UID
+                rr['uid'] = s_uid
+                new_rr.append(rr)
             specs[n] = new_rr
             n += 1
         return json.dumps(specs)

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -23,6 +23,7 @@ from Products.Archetypes import PloneMessageFactory as PMF
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from zope.component import getAdapter
 from zope.interface import implements
 
@@ -223,6 +224,8 @@ class AnalysisRequestAddView(AnalysisRequestViewView):
     def __call__(self):
         self.request.set('disable_border', 1)
         self.ShowPrices = self.context.bika_setup.getShowPrices()
+        self.analysisrequest_catalog =\
+            getToolByName(self.context, CATALOG_ANALYSIS_REQUEST_LISTING)
         if 'ajax_category_expand' in self.request.keys():
             cat = self.request.get('cat')
             asv = AnalysisServicesView(self.context,
@@ -239,16 +242,16 @@ class AnalysisRequestAddView(AnalysisRequestViewView):
         copy_from = self.request.get('copy_from', "")
         if not copy_from:
             return {}
-        uids =  copy_from.split(",")
-
+        uids = copy_from.split(",")
         n = 0
         for uid in uids:
-            proxies = self.bika_catalog(UID=uid)
-            rr = proxies[0].getObject().getResultsRange()
+            proxies = self.analysisrequest_catalog(UID=uid)
+            rr = proxies[0].getObject().getResultsRange() if proxies else []
             new_rr = []
             for i, r in enumerate(rr):
-                s_uid = self.bika_setup_catalog(portal_type='AnalysisService',
-                                              getKeyword=r['keyword'])[0].UID
+                s_uid = self.bika_setup_catalog(
+                    portal_type='AnalysisService',
+                    getKeyword=r['keyword'])[0].UID
                 r['uid'] = s_uid
                 new_rr.append(r)
             specs[n] = new_rr


### PR DESCRIPTION
Use analysis request catalog and preventive conditional added.

```
IndexError: 0

 - Expression: "here/main_template/macros/master"
 - Filename:   ... ms/bika/lims/browser/analysisrequest/templates/ar_add.pt
 - Location:   (line 4: col 25)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f0593cc4410>
               views: <ViewMapper - at 0x7f05934fbe50>
               modules: <instance - at 0x7f05bc928518>
               args: <tuple - at 0x7f05c78ce050>
               here: <ImplicitAcquisitionWrapper Request new analyses at 0x7f058daeeaa0>
               user: <ImplicitAcquisitionWrapper - at 0x7f055d9011e0>
               loop: {...} (1)
               nothing: <NoneType - at 0x7ab150>
               translate: <function translate at 0x7f0590151de8>
               container: <ImplicitAcquisitionWrapper Request new analyses at 0x7f058daeeaa0>
               request: <instance - at 0x7f0592495ef0>
               wrapped_repeat: <SafeMapping - at 0x7f055ed91100>
               traverse_subpath: <list - at 0x7f0594e838c0>
               default: <object - at 0x7f05c78a4c40>
               context: <ImplicitAcquisitionWrapper Request new analyses at 0x7f058daeeaa0>
               view: <AnalysisRequestAddView ar_add at 0x7f055d982f50>
               target_language: <NoneType - at 0x7ab150>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f05a9c42690>
               options: {...} (0)
(18 additional frame(s) were not displayed)
...
  File "340eb0fb04d6cce4b1f1ed98ca09fe08.py", line 484, in render_content
  File "d322babe1ded19a8cb8a121560a94b06.py", line 646, in __fill_content_core
  File "home/lims/Plone/buildout-cache/eggs/five.pt-2.2.4-py2.7.egg/five/pt/expressions.py", line 161, in __call__
    return base()
  File "home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/analysisrequest/add.py", line 247, in copy_to_new_specs
    rr = proxies[0].getObject().getResultsRange()
  File "home/lims/Plone/buildout-cache/eggs/Products.ZCatalog-2.13.27-py2.7.egg/Products/ZCatalog/Lazy.py", line 132, in __getitem__
    raise IndexError(index)

1491220111.830.130910591835 http://<IP>/clients/client-1244/portal_factory/AnalysisRequest/Request new analyses/ar_add
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.FactoryTool, line 478, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.add, line 30, in __call__
  Module bika.lims.browser.analysisrequest.add, line 235, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module d322babe1ded19a8cb8a121560a94b06.py, line 1068, in render
  Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 1172, in render_master
  Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 484, in render_content
  Module d322babe1ded19a8cb8a121560a94b06.py, line 646, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.analysisrequest.add, line 247, in copy_to_new_specs
  Module Products.ZCatalog.Lazy, line 132, in __getitem__
IndexError: 0

 - Expression: "here/main_template/macros/master"
 - Filename:   ... ms/bika/lims/browser/analysisrequest/templates/ar_add.pt
 - Location:   (line 4: col 25)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f0593cc4410>
               views: <ViewMapper - at 0x7f05934fbe50>
               modules: <instance - at 0x7f05bc928518>
               args: <tuple - at 0x7f05c78ce050>
               here: <ImplicitAcquisitionWrapper Request new analyses at 0x7f058daeeaa0>
               user: <ImplicitAcquisitionWrapper - at 0x7f055d9011e0>
               loop: {...} (1)
               nothing: <NoneType - at 0x7ab150>
               translate: <function translate at 0x7f0590151de8>
               container: <ImplicitAcquisitionWrapper Request new analyses at 0x7f058daeeaa0>
               request: <instance - at 0x7f0592495ef0>
               wrapped_repeat: <SafeMapping - at 0x7f055ed91100>
               traverse_subpath: <list - at 0x7f0594e838c0>
               default: <object - at 0x7f05c78a4c40>
               context: <ImplicitAcquisitionWrapper Request new analyses at 0x7f058daeeaa0>
               view: <AnalysisRequestAddView ar_add at 0x7f055d982f50>
               target_language: <NoneType - at 0x7ab150>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f05a9c42690>
               options: {...} (0)
```