### PR TITLE
NMRL-262 Fix error while creating a Reference Analysis

### DIFF
--- a/bika/lims/content/referencesample.py
+++ b/bika/lims/content/referencesample.py
@@ -316,31 +316,34 @@ class ReferenceSample(BaseFolder):
 
     security.declarePublic('addReferenceAnalysis')
     def addReferenceAnalysis(self, service_uid, reference_type):
-        """ add an analysis to the sample """
+        """
+        Creates a new Reference Analysis object based on this Sample
+        Reference, with the type passed in and associates the newly
+        created object to the Analysis Service passed in.
+
+        :param service_uid: The UID of the Analysis Service to be
+            associated to the newly created Reference Analysis
+        :type service_uid: A string
+        :param reference_type: type of ReferenceAnalysis, where 'b' is
+            is Blank and 'c' is Control
+        :type reference_type: A String
+        :returns: the UID of the newly created Reference Analysis
+        :rtype: A string
+        """
         rc = getToolByName(self, REFERENCE_CATALOG)
         service = rc.lookupObject(service_uid)
+        calc = service.getCalculation()
+        interim_fields = calc.getInterimFields() if calc else None
+        interim_fields = interim_fields if interim_fields else []
 
-        analysis = _createObjectByType("ReferenceAnalysis", self, tmpID())
+        analysis = _createObjectByType("ReferenceAnalysis",
+                                        self,
+                                        id=tmpID(),
+                                        Service=service,
+                                        ReferenceType=reference_type,
+                                        InterimFields=interim_fields)
         analysis.unmarkCreationFlag()
-
-        calculation = service.getCalculation()
-        interim_fields = calculation and calculation.getInterimFields() or []
         renameAfterCreation(analysis)
-
-        # maxtime = service.getMaxTimeAllowed() and service.getMaxTimeAllowed() \
-        #     or {'days':0, 'hours':0, 'minutes':0}
-        # starttime = DateTime()
-        # max_days = float(maxtime.get('days', 0)) + \
-        #          (
-        #              (float(maxtime.get('hours', 0)) * 3600 + \
-        #               float(maxtime.get('minutes', 0)) * 60)
-        #              / 86400
-        #          )
-        # duetime = starttime + max_days
-
-        analysis.setReferenceType(reference_type)
-        analysis.setService(service_uid)
-        analysis.setInterimFields(interim_fields)
         return analysis.UID()
 
 


### PR DESCRIPTION
Fixes NMRL-262 and NMRL-263

Some fields from ReferenceAnalysis object are indexed at creation time, but its value depends on the Service associated to the ReferenceAnalysis.

The Service was assigned to the ReferenceAnalysis after its creation, so exceptions like the one below were raised while _createObjectByType:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.worksheet.views.add_blank, line 56, in __call__
  Module bika.lims.content.worksheet, line 309, in addReferences
  Module bika.lims.content.referencesample, line 323, in addReferenceAnalysis
  Module Products.CMFPlone.utils, line 333, in _createObjectByType
  Module Products.CMFCore.TypesTool, line 559, in _constructInstance
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module Products.CMFCore.CMFCatalogAware, line 262, in handleContentishEvent
  Module Products.CMFCore.CMFCatalogAware, line 188, in notifyWorkflowCreated
  Module Products.CMFCore.WorkflowTool, line 289, in notifyCreated
  Module Products.CMFCore.WorkflowTool, line 635, in _reindexWorkflowVariables
  Module Products.Archetypes.CatalogMultiplex, line 118, in reindexObject
  Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 476, in catalog_object
  Module Products.ZCatalog.Catalog, line 334, in catalogObject
  Module Products.ZCatalog.Catalog, line 284, in updateMetadata
  Module Products.ZCatalog.Catalog, line 410, in recordify
  Module bika.lims.content.referenceanalysis, line 261, in isInstrumentValid
AttributeError: 'NoneType' object has no attribute 'getInstrumentEntryOfResults'
```