### PR TITLE
Fix error when an object has no status defined while listing in WS

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -934,6 +934,11 @@ class BikaListingView(BrowserView):
             modified = self.ulocalized_time(obj.modified()),
             state_class = ''
             states = obj.getObjectWorkflowStates
+            if not states:
+                logger.warning(
+                    'No workflow states found for object with id {0}'
+                    .format(obj.getId))
+                states = {}
             states = states if states else {}
             for w_id in states.keys():
                 state_class += "state-%s " % states.get(w_id, '')
@@ -943,7 +948,7 @@ class BikaListingView(BrowserView):
                 obj=obj,
                 uid=obj.UID,
                 url=obj.getURL(),
-                id=obj.id,
+                id=obj.getId,
                 title=obj.Title,
                 # To colour the list items by state
                 state_class=state_class,

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -934,6 +934,7 @@ class BikaListingView(BrowserView):
             modified = self.ulocalized_time(obj.modified()),
             state_class = ''
             states = obj.getObjectWorkflowStates
+            states = states if states else {}
             for w_id in states.keys():
                 state_class += "state-%s " % states.get(w_id, '')
             # Building the dictionary with basic items

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -979,7 +979,7 @@ class BikaListingView(BrowserView):
                 st_title = t(PMF(st_title))
             except:
                 logger.warning(
-                    "Workflow title doesn't obtined for object %s" % obj.id)
+                    "Workflow title doesn't obtined for object %s" % obj.getId)
                 rs = 'active'
                 st_title = None
             for state_var, state in states.items():

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3200</version>
+  <version>3.2.0.1704</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -577,6 +577,7 @@ class BikaGenerator:
         addColumn(bc, 'path')
         addColumn(bc, 'UID')
         addColumn(bc, 'id')
+        addColumn(bc, 'getId')
         addColumn(bc, 'Type')
         addColumn(bc, 'portal_type')
         addColumn(bc, 'creator')

--- a/bika/lims/upgrade/__init__.py
+++ b/bika/lims/upgrade/__init__.py
@@ -6,7 +6,7 @@
 # see https://gist.github.com/malthe/704910
 import imp
 import sys
-
+from Products.CMFCore.utils import getToolByName
 
 def create_modules(module_path):
     path = ""
@@ -45,3 +45,14 @@ def skip_pre315(portal):
     if info['installedVersion'] > '315':
         return True
     return False
+
+
+def upgradestep(upgrade_product, version):
+    """ Decorator for updating the QuickInstaller of a upgrade """
+    def wrap_func(fn):
+        def wrap_func_args(context, *args):
+            p = getToolByName(context, 'portal_quickinstaller').get(upgrade_product)
+            setattr(p, 'installedversion', version)
+            return fn(context, *args)
+        return wrap_func_args
+    return wrap_func

--- a/bika/lims/upgrade/__init__.py
+++ b/bika/lims/upgrade/__init__.py
@@ -40,11 +40,9 @@ def skip_pre315(portal):
     # Hack prevent out-of-date upgrading
     # Related: PR #1484
     # https://github.com/bikalabs/Bika-LIMS/pull/1484
-    qi = portal.portal_quickinstaller
-    info = qi.upgradeInfo('bika.lims')
-    if info['installedVersion'] > '315':
-        return True
-    return False
+    from bika.lims.upgrade.utils import UpgradeUtils
+    ut = UpgradeUtils(portal)
+    return ut.isOlderVersion('bika.lims', '315')
 
 
 def upgradestep(upgrade_product, version):

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -572,7 +572,7 @@
 
  <genericsetup:upgradeStep
          title="Upgrade to Bika LIMS 3.2.0"
-         description="This is the upgrade step to drive bikaLIMS ot 3.2 version."
+         description="This is the upgrade step to drive Bika LIMS at 3.2 version."
          source="320"
          destination="3200"
          handler="bika.lims.upgrade.to320.upgrade"
@@ -581,10 +581,19 @@
 
  <genericsetup:upgradeStep
          title="Upgrade to Bika LIMS 3.2.0"
-         description="This is the upgrade step to drive bikaLIMS ot 3.2 version."
+         description="This is the upgrade step to drive BikaLIMS at 3.2 version."
          source="3111"
          destination="3200"
          handler="bika.lims.upgrade.to320.upgrade"
          sortkey="1"
          profile="bika.lims:default"/>
+
+ <genericsetup:upgradeStep
+         title="Upgrade to Bika LIMS 3.2.0.1704"
+         source="3200"
+         destination="3.2.0.1704"
+         handler="bika.lims.upgrade.v3_2_0_1704.upgrade"
+         sortkey="1"
+         profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -572,20 +572,16 @@
 
  <genericsetup:upgradeStep
          title="Upgrade to Bika LIMS 3.2.0"
-         description="This is the upgrade step to drive Bika LIMS at 3.2 version."
          source="320"
          destination="3200"
          handler="bika.lims.upgrade.to320.upgrade"
-         sortkey="1"
          profile="bika.lims:default"/>
 
  <genericsetup:upgradeStep
          title="Upgrade to Bika LIMS 3.2.0"
-         description="This is the upgrade step to drive BikaLIMS at 3.2 version."
          source="3111"
          destination="3200"
          handler="bika.lims.upgrade.to320.upgrade"
-         sortkey="1"
          profile="bika.lims:default"/>
 
  <genericsetup:upgradeStep
@@ -593,7 +589,6 @@
          source="3200"
          destination="3.2.0.1704"
          handler="bika.lims.upgrade.v3_2_0_1704.upgrade"
-         sortkey="1"
          profile="bika.lims:default"/>
 
 </configure>

--- a/bika/lims/upgrade/utils.py
+++ b/bika/lims/upgrade/utils.py
@@ -1,0 +1,117 @@
+
+from Products.CMFCore.utils import getToolByName
+from bika.lims import logger
+
+import traceback
+import sys
+import transaction
+
+
+class UpgradeUtils(object):
+
+    def __init__(self, portal):
+        self.portal = portal
+        self.reindexcatalog = {}
+        self.refreshcatalog = []
+
+    def delIndexAndColumn(self, catalog, index):
+        self.delIndex(catalog, index)
+        self.delColumn(catalog, index)
+
+    def addIndexAndColumn(self, catalog, index, indextype):
+        self.addIndex(catalog, index, indextype)
+        self.addColumn(catalog, index)
+
+    def reindexAndRefresh(self):
+        self.reindexCatalogs()
+        self.refreshCatalogs()
+
+    def _getCatalog(self, catalog):
+        if isinstance(catalog, str):
+            return getToolByName(self.portal, catalog)
+        return catalog
+
+    def delIndex(self, catalog, index):
+        cat = self._getCatalog(catalog)
+        if index not in cat.indexes():
+            return
+        try:
+            cat.delIndex(index)
+            logger.info('Deleted index {0} from catalog {1}'.format(
+                        index, cat.id))
+            transaction.commit()
+        except:
+            logger.error(
+                'Unable to delete index {0} from catalog {1}'.format(
+                    index, cat.id))
+
+    def delColumn(self, catalog, column):
+        cat = self._getCatalog(catalog)
+        if column not in cat.schema():
+            return
+        try:
+            cat.delColumn(column)
+            logger.info('Deleted column {0} from catalog {1} deleted.'.format(
+                        column, cat.id))
+            transaction.commit()
+        except:
+            logger.error(
+                'Unable to delete column {0} from catalog {1}'.format(
+                    column, cat.id))
+
+    def addIndex(self, catalog, index, indextype):
+        cat = self._getCatalog(catalog)
+        if index in cat.indexes():
+            return
+        try:
+            cat.addIndex(index, indextype)
+            logger.info('Catalog index %s added.' % index)
+            indexes = self.reindexcatalog.get(cat.id, [])
+            indexes.append(index)
+            indexes = list(set(indexes))
+            self.reindexcatalog[cat.id] = indexes
+            transaction.commit()
+        except:
+            logger.error(
+                'Unable to add index {0} to catalog {1}'.format(
+                    index, cat.id))
+
+    def addColumn(self, catalog, column):
+        cat = self._getCatalog(catalog)
+        if column in cat.schema():
+            return
+        try:
+            cat.addColumn(column)
+            logger.info('Added column {0} to catalog {1}'.format(
+                column, cat.id))
+            if cat.id not in self.refreshcatalog:
+                self.refreshcatalog.append(cat.id)
+            transaction.commit()
+        except:
+            logger.error(
+                'Unable to add column {0} to catalog {1}'.format(
+                    column, cat.id))
+
+    def refreshCatalogs(self):
+        cats = self.refreshcatalog + self.reindexcatalog.keys()
+        cats = list(set(cats))
+        for catalogid in cats:
+            try:
+                catalog = getToolByName(self.portal, catalogid)
+                catalog.refreshCatalog()
+                logger.info('Catalog {0} refreshed'.format(catalogid))
+                transaction.commit()
+            except:
+                logger.error('Unable to refresh catalog {0}'.format(catalogid))
+
+    def cleanAndRebuildCatalogs(self):
+        cats = self.refreshcatalog + self.reindexcatalog.keys()
+        for catid in cats:
+            try:
+                catalog = getToolByName(self.portal, catid)
+                catalog.clearFindAndRebuild()
+                logger.info('Catalog {0} cleaned and rebuilt'.format(catid))
+                transaction.commit()
+            except:
+                logger.error('Unable to clean and rebuild catalog {0}'.format(
+                            catid))

--- a/bika/lims/upgrade/v3_2_0_1704.py
+++ b/bika/lims/upgrade/v3_2_0_1704.py
@@ -17,9 +17,11 @@ version = '3.2.0.1704'
 
 @upgradestep(product, version)
 def upgrade(tool):
-    logger.info("Upgrading {0} to {1}".format(product, version))
-
     portal = aq_parent(aq_inner(tool))
+    qi = portal.portal_quickinstaller
+    ufrom = qi.upgradeInfo(product)['installedVersion']
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
+
     ut = UpgradeUtils(portal)
 
     # Add getId column to bika_catalog

--- a/bika/lims/upgrade/v3_2_0_1704.py
+++ b/bika/lims/upgrade/v3_2_0_1704.py
@@ -1,0 +1,32 @@
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import logger
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+import traceback
+import sys
+import transaction
+
+product = 'bika.lims'
+version = '3.2.0.1704'
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    logger.info("Upgrading {0} to {1}".format(product, version))
+
+    portal = aq_parent(aq_inner(tool))
+    ut = UpgradeUtils(portal)
+
+    # Add getId column to bika_catalog
+    ut.addColumn('bika_catalog', 'getId')
+
+    # Refresh affected catalogs
+    ut.refreshCatalogs()
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True

--- a/bika/lims/upgrade/v3_2_0_1704.py
+++ b/bika/lims/upgrade/v3_2_0_1704.py
@@ -18,11 +18,16 @@ version = '3.2.0.1704'
 @upgradestep(product, version)
 def upgrade(tool):
     portal = aq_parent(aq_inner(tool))
-    qi = portal.portal_quickinstaller
-    ufrom = qi.upgradeInfo(product)['installedVersion']
-    logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
-
     ut = UpgradeUtils(portal)
+    ufrom = ut.getInstalledVersion(product)
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+                    product, ufrom, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
 
     # Add getId column to bika_catalog
     ut.addColumn('bika_catalog', 'getId')

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,4 +1,4 @@
-3.2.1 (unreleased)
+3.2.0 (unreleased)
 ------------------
 - Allow multi-approval (multi-verification) of results
 HEALTH-568: TaqMan 96 Interface not working well

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.2.1'
+version = '3.2.0'
 
 
 def read(*rnames):


### PR DESCRIPTION
Happened after creating a ReferenceAnalysis:

```
1492095243.720.42824301321 http://localhost:8080/Plone/worksheets/WS-003/manage_results
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.worksheet.views.results, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 261, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module e8dd4d0250ff52f7615885d10c907454.py, line 1671, in render
  Module 577340f402cac729036f9610038b788b.py, line 1392, in render_master
  Module 577340f402cac729036f9610038b788b.py, line 559, in render_content
  Module e8dd4d0250ff52f7615885d10c907454.py, line 1563, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1279, in contents_table
  Module bika.lims.browser.bika_listing, line 1440, in __init__
  Module bika.lims.browser.worksheet.views.analyses, line 75, in folderitems
  Module bika.lims.browser.analyses, line 930, in folderitems
  Module bika.lims.browser.bika_listing, line 937, in folderitems
TypeError: 'Missing.Value' object is not iterable

 - Expression: "view/Analyses/contents_table"
 - Filename:   ... ika/lims/browser/worksheet/views/../templates/results.pt
 - Location:   (line 159: col 33)
 - Source:     ... replace="structure view/Analyses/contents_table"/>
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f5adb6c3ed0>
               views: <ViewMapper - at 0x7f5adb6c3dd0>
               modules: <instance - at 0x7f5afc518638>
               args: <tuple - at 0x7f5b071aa050>
               here: <ImplicitAcquisitionWrapper WS-003 at 0x7f5aef77ae10>
               user: <ImplicitAcquisitionWrapper - at 0x7f5aef63dc30>
               nothing: <NoneType - at 0x7ab150>
               target_language: <NoneType - at 0x7ab150>
               translate: <function translate at 0x7f5adbf5fb90>
               container: <ImplicitAcquisitionWrapper WS-003 at 0x7f5aef77ae10>
               request: <instance - at 0x7f5adbe0c8c0>
               wrapped_repeat: <SafeMapping - at 0x7f5adbffd838>
               traverse_subpath: <list - at 0x7f5adbe581b8>
               default: <object - at 0x7f5b07180c40>
               loop: {...} (3)
               context: <ImplicitAcquisitionWrapper WS-003 at 0x7f5aef77ae10>
               view: <ManageResultsView manage_results at 0x7f5adbff1f10>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f5aef76bb90>
               options: {...} (0)
               last_uid: ba7e114944e543dab76c636ac942059c
```