### PR TITLE
NMRL-222 Worksheets view. TypeError: 'list' object is not callable

### DIFF
--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -249,25 +249,24 @@ class FolderView(BikaListingView):
             being displayed
         :rtype: bool
         """
-        if self.selected_state == 'mine' or self.restrict_results:
-            analyst = obj.getAnalyst
-            if analyst != _c(self.member.getId()):
-                return False
+        if (self.selected_state == 'mine' or self.restrict_results) \
+            and obj.getAnalyst != _c(self.member.getId()):
+            # Check if the current WS is assigned to the current user
+            return False
+
         if not self.allowed_department_filtering:
+            # Filtering by department is disabled. Return True
             return True
-        # Gettin the department from worksheet
-        deps = obj.getDepartmentUIDs()
-        result = True
-        if deps:
-            # Getting the cookie value
-            cookie_dep_uid = self.request.get('filter_by_department_info', '')
-            # Comparing departments' UIDs
-            deps_uids = set(deps)
-            filter_uids = set(
-                cookie_dep_uid.split(','))
-            matches = deps_uids & filter_uids
-            result = len(matches) > 0
-        return result
+
+        # Department filtering is enabled. Check if at least one of the
+        # analyses associated to this worksheet belongs to at least one
+        # of the departments currently selected.
+        cdepuids = self.request.get('filter_by_department_info', '')
+        cdepuids = cdepuids.split(',') if cdepuids else []
+        deps = obj.getDepartmentUIDs
+        allowed = [d for d in obj.getDepartmentUIDs if d in cdepuids]
+        return len(allowed) > 0
+
 
     def folderitem(self, obj, item, index):
         """

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -1250,6 +1250,13 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         return []
 
     def getDepartmentUIDs(self):
-        return [an.getDepartmentUID() for an in self.getAnalyses()]
+        """
+        Returns a list of department uids to which the analyses from
+        this Worksheet belong to. The list has no duplicates.
+        :returns: a list of uids
+        :rtype: list
+        """
+        analyses = self.getAnalyses()
+        return list(set([an.getDepartmentUID() for an in analyses]))
 
 registerType(Worksheet, PROJECTNAME)


### PR DESCRIPTION
`obj` param is a brain, not an ATContent. Done some code cleaning too.

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 804, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 276, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module b3db0640eb90d28b2c249699f57068cc.py, line 846, in render
  Module 3cd558b0ecf4f5881bee7d47c02abbda.py, line 1420, in render_master
  Module 3cd558b0ecf4f5881bee7d47c02abbda.py, line 578, in render_content
  Module b3db0640eb90d28b2c249699f57068cc.py, line 812, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1279, in contents_table
  Module bika.lims.browser.bika_listing, line 1440, in __init__
  Module bika.lims.browser.worksheet.views.folder, line 327, in folderitems
  Module bika.lims.browser.bika_listing, line 932, in folderitems
  Module bika.lims.browser.worksheet.views.folder, line 259, in isItemAllowed
TypeError: 'list' object is not callable

 - Expression: "view/contents_table"
 - Filename:   ... /lims/browser/worksheet/views/../templates/worksheets.pt
 - Location:   (line 89: col 31)
 - Source:     tal:content="structure view/contents_table"/>
                                      ^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f7f04839090>
               views: <ViewMapper - at 0x7f7f0c583090>
               modules: <instance - at 0x7f7f244511b8>
               args: <tuple - at 0x7f7f2f289050>
               here: <ImplicitAcquisitionWrapper worksheets at 0x7f7f0c526820>
               user: <ImplicitAcquisitionWrapper - at 0x7f7f0c04fe10>
               nothing: <NoneType - at 0x7b1070>
               translate: <function translate at 0x7f7f047c9c80>
               container: <ImplicitAcquisitionWrapper worksheets at 0x7f7f0c526820>
               request: <instance - at 0x7f7f0c04bf80>
               wrapped_repeat: <SafeMapping - at 0x7f7f149e0838>
               traverse_subpath: <list - at 0x7f7f0c8c71b8>
               default: <object - at 0x7f7f2f25fc30>
               loop: {...} (3)
               context: <ImplicitAcquisitionWrapper worksheets at 0x7f7f0c526820>
               view: <FolderView base_view at 0x7f7f0c3aca50>
               target_language: <NoneType - at 0x7b1070>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f7efb755d70>
               options: {...} (0)
```