### PR TITLE
Error while listing analyses in Analysis Request details view

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -1049,7 +1049,7 @@ class QCAnalysesView(AnalysesView):
         qcanalyses = context.getQCAnalyses()
         asuids = [an.UID() for an in qcanalyses]
         self.contentFilter = {'UID': asuids,
-                              'sort_on': 'sortable_title'}
+                              'sort_on': 'getId'}
         self.icon = self.portal_url + \
                     "/++resource++bika.lims.images/referencesample.png"
 

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -56,7 +56,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
         self.columns = {
             'Title': {'title': _('Service'),
-                      'index': 'sortable_title',
+                      'index': 'getId',
                       'sortable': False, },
             'Hidden': {'title': _('Hidden'),
                        'sortable': False,

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -70,7 +70,7 @@ class AddAnalysesView(BikaListingView):
                 'index': 'getCategoryTitle'},
             'Title': {
                 'title': _('Analysis'),
-                'index':'sortable_title'},
+                'index':'getId'},
             'getDateReceived': {
                 'title': _('Date Received'),
                 'index': 'getDateReceived'},


### PR DESCRIPTION
The index sortable_title is not available in bika_analysis_catalog, so the
following error is rised in AR's detail view:

```
http://localhost:8080/Plone/clients/client-1/AP-0001-R01/base_view
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.view, line 17, in __call__
  Module bika.lims.browser.analysisrequest.view, line 115, in __call__
  Module bika.lims.browser.bika_listing, line 1279, in contents_table
  Module bika.lims.browser.bika_listing, line 1440, in __init__
  Module bika.lims.browser.analyses, line 1088, in folderitems
  Module bika.lims.browser.analyses, line 930, in folderitems
  Module bika.lims.browser.bika_listing, line 912, in folderitems
  Module Products.CMFPlone.CatalogTool, line 389, in searchResults
  Module Products.ZCatalog.ZCatalog, line 604, in searchResults
  Module Products.ZCatalog.Catalog, line 916, in searchResults
  Module Products.ZCatalog.Catalog, line 889, in _getSortIndex
CatalogError: Unknown sort_on index (sortable_title)
```