### PR TITLE
Selecting a sticker template in AR's sticker preview does nothing

### DIFF
--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -28,10 +28,10 @@ class Sticker(BrowserView):
     def __call__(self):
         self.rendered_items = []
         items = self.request.get('items', '')
-        if items:
-            catalog = getToolByName(self.context, 'uid_catalog')
-            self.items = [o.getObject() for o in catalog(UID=items.split(","))]
-        else:
+        catalog = getToolByName(self.context, 'uid_catalog')
+        self.items = [o.getObject() for o in catalog(UID=items.split(","))]
+        if not self.items:
+            # Default fallback, load from context
             self.items = [self.context, ]
 
         new_items = []

--- a/bika/lims/tests/test_showpartitions.py
+++ b/bika/lims/tests/test_showpartitions.py
@@ -69,7 +69,7 @@ class TestShowPartitions(BikaSimpleTestCase):
             doActionFor(ar, 'receive')
             self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'), 'sample_received')
             # check sticker text
-            ar.REQUEST['items'] = ar.getId()
+            ar.REQUEST['items'] = ar.UID()
             ar.REQUEST['template'] = stemp.get('id')
             sticker = Sticker(ar, ar.REQUEST)()
             pid = ar.getSample().objectValues("SamplePartition")[0].getId()
@@ -81,7 +81,7 @@ class TestShowPartitions(BikaSimpleTestCase):
             doActionFor(ar, 'receive')
             self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'), 'sample_received')
             # check sticker text
-            ar.REQUEST['items'] = ar.getId()
+            ar.REQUEST['items'] = ar.UID()
             ar.REQUEST['template'] = stemp.get('id')
             sticker = Sticker(ar, ar.REQUEST)()
             pid = ar.getSample().objectValues("SamplePartition")[0].getId()


### PR DESCRIPTION
The sticker browser view assumes an 'items' param in request that contains UIDs from the objects for which the sticker/s must be rendered, but when visualizing the preview directly from an AR details view,
the value for the passed in parameter item is the RequestID.

Use the context as default fallback if no objects found for the value set in items param from request.