### PR TITLE
NMRL-259 AR Publish. AttributeError: getRequestID

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -275,7 +275,7 @@ class AnalysisRequestPublishView(BrowserView):
         if ar.UID() in self._cache['_ar_data']:
             return self._cache['_ar_data'][ar.UID()]
         data = {'obj': ar,
-                'id': ar.getRequestID(),
+                'id': ar.getId(),
                 'client_order_num': ar.getClientOrderNumber(),
                 'client_reference': ar.getClientReference(),
                 'client_sampleid': ar.getClientSampleID(),


### PR DESCRIPTION
Use getId instead of getRequestID

```
1491967617.170.0694255655463 http://10.67.1.6/analysisrequests/publish
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.publish, line 11, in __call__
  Module bika.lims.browser.analysisrequest.publish, line 113, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module d5fed8836304a5fa7846db8757afa826.py, line 973, in render
  Module bika.lims.browser.analysisrequest.publish, line 152, in getAnalysisRequest
  Module bika.lims.browser.analysisrequest.publish, line 278, in _ar_data
AttributeError: getRequestID

 - Expression: "python:('ar_publish_body singlear %s' % ('ar-invalid' if hasattr(view.getAnalysisRequestObj(),'isInvalid') and view.getAnalysisRequestObj().isInvalid() else ('ar-provisional' if view.getAnalysisRequest()['prepublish']==True else '')))"
 - Filename:   ... ser/analysisrequest/templates/analysisrequest_publish.pt
 - Location:   (line 240: col 32)
 - Source:     ... python:('ar_publish_body singlear %s' % ('ar-invalid' if hasattr(view.getAnalysisRequestObj(),'isInvalid') and view.getAnalysisRequestObj().isInvalid() else ('ar-provisional' if view.getAnalysisRequest()['prepublish']==True else ''))) ...
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  default: <object - at 0x7ff375141c40>
               repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7ff32a7e6d10>
               views: <ViewMapper - at 0x7ff323a2ce90>
               modules: <instance - at 0x7ff36a1c55a8>
               args: <tuple - at 0x7ff37516b050>
               here: <ImplicitAcquisitionWrapper analysisrequests at 0x7ff331045e10>
               portal: <ImplicitAcquisitionWrapper Plone at 0x7ff33071d320>
               user: <ImplicitAcquisitionWrapper - at 0x7ff353fa90f0>
               nothing: <NoneType - at 0x7ab150>
               plone_view: <Plone plone at 0x7ff32d74eb50>
               container: <ImplicitAcquisitionWrapper analysisrequests at 0x7ff331045e10>
               i: 0
               request: <instance - at 0x7ff3296d8bd8>
               wrapped_repeat: <SafeMapping - at 0x7ff306711db8>
               portal_url: http://10.67.1.6
               traverse_subpath: <list - at 0x7ff3296d8440>
               loop: {...} (3)
               context: <ImplicitAcquisitionWrapper analysisrequests at 0x7ff331045e10>
               view: <AnalysisRequestPublishView publish at 0x7ff323a2ca90>
               portal_state: <PortalState plone_portal_state at 0x7ff32d74ed10>
               translate: <function translate at 0x7ff308b18cf8>
               root: <ImplicitAcquisitionWrapper Zope at 0x7ff327259820>
               options: {...} (0)
               target_language: <NoneType - at 0x7ab150>

```