### PR TITLE
NMRL-229 Wildcards on searching lists

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -680,6 +680,11 @@ class BikaListingView(BrowserView):
                     continue
                 ##logger.info("Or: %s=%s"%(index, value))
                 if idx.meta_type in('ZCTextIndex', 'FieldIndex'):
+                    # For SearchableText index, we search for any value
+                    # starting with keyword. Unfortunately for ZCTextIndexes
+                    # regex cannot start with special character like '*'
+                    if idx.meta_type == 'ZCTextIndex':
+                        value += '*'
                     self.Or.append(MatchRegexp(index, value))
                     self.expand_all_categories = True
                     # https://github.com/bikalabs/Bika-LIMS/issues/1069

--- a/bika/lims/catalog/catalog_utilities.py
+++ b/bika/lims/catalog/catalog_utilities.py
@@ -293,7 +293,10 @@ def _addIndex(catalog, index, indextype):
     """
     if index not in catalog.indexes():
         try:
-            catalog.addIndex(index, indextype)
+            if indextype == 'ZCTextIndex':
+                addZCTextIndex(catalog, index)
+            else:
+                catalog.addIndex(index, indextype)
             logger.info('Catalog index %s added to %s.' % (index, catalog.id))
             return True
         except:
@@ -365,6 +368,37 @@ def _delColumn(cat, col):
     return False
 
 
+def addZCTextIndex(catalog, index_name):
+
+    if catalog is None:
+        logger.warning('Could not find the catalog tool.' + catalog)
+        return
+
+    # Create lexicon to be able to add ZCTextIndex
+    wordSplitter = Empty()
+    wordSplitter.group = 'Word Splitter'
+    wordSplitter.name = 'Unicode Whitespace splitter'
+    caseNormalizer = Empty()
+    caseNormalizer.group = 'Case Normalizer'
+    caseNormalizer.name = 'Unicode Case Normalizer'
+    stopWords = Empty()
+    stopWords.group = 'Stop Words'
+    stopWords.name = 'Remove listed and single char words'
+    elem = [wordSplitter, caseNormalizer, stopWords]
+    zc_extras = Empty()
+    zc_extras.index_type = 'Okapi BM25 Rank'
+    zc_extras.lexicon_id = 'Lexicon'
+
+    try:
+        catalog.manage_addProduct['ZCTextIndex'].manage_addLexicon('Lexicon',
+                                                               'Lexicon', elem)
+    except:
+        logger.warning('Could not add ZCTextIndex to '+str(catalog))
+        pass
+
+    catalog.addIndex(index_name, 'ZCTextIndex', zc_extras)
+
+
 def _cleanAndRebuildIfNeeded(portal, cleanrebuild):
     """
     Rebuild the given catalogs.
@@ -377,3 +411,7 @@ def _cleanAndRebuildIfNeeded(portal, cleanrebuild):
             catalog.clearFindAndRebuild()
         else:
             logger.warning('%s do not found' % cat)
+
+
+class Empty:
+    pass

--- a/bika/lims/catalog/catalog_utilities.py
+++ b/bika/lims/catalog/catalog_utilities.py
@@ -394,7 +394,6 @@ def addZCTextIndex(catalog, index_name):
                                                                'Lexicon', elem)
     except:
         logger.warning('Could not add ZCTextIndex to '+str(catalog))
-        pass
 
     catalog.addIndex(index_name, 'ZCTextIndex', zc_extras)
 
@@ -414,4 +413,8 @@ def _cleanAndRebuildIfNeeded(portal, cleanrebuild):
 
 
 class Empty:
+    """
+    Just a class to use when we need an object with some attributes to send to
+    another objects an a parameter.
+    """
     pass

--- a/bika/lims/upgrade/utils.py
+++ b/bika/lims/upgrade/utils.py
@@ -1,6 +1,7 @@
 
 from Products.CMFCore.utils import getToolByName
 from bika.lims import logger
+from bika.lims.catalog.catalog_utilities import addZCTextIndex
 
 import traceback
 import sys
@@ -102,7 +103,10 @@ class UpgradeUtils(object):
         if index in cat.indexes():
             return
         try:
-            cat.addIndex(index, indextype)
+            if indextype == 'ZCTextIndex':
+                addZCTextIndex(cat, index)
+            else:
+                cat.addIndex(index, indextype)
             logger.info('Catalog index %s added.' % index)
             indexes = self.reindexcatalog.get(cat.id, [])
             indexes.append(index)


### PR DESCRIPTION
For SearchableText indexes, we can use Regex `(keyword+ '*' )` in order to find all records starting with keyword, not only matching the keyword ones.
https://github.com/naralabs/bika.health/pull/18