### PR TITLE
Client ARs view. AttributeError: bika_catalog

### DIFF
--- a/bika/lims/workflow.py
+++ b/bika/lims/workflow.py
@@ -20,6 +20,7 @@ from zope.component import adapts
 from zope.interface import implementer
 from zope.interface import implements
 from zope.interface import Interface
+import traceback
 
 
 def skip(instance, action, peek=False, unskip=False):
@@ -234,7 +235,14 @@ def SamplePrepWorkflowChain(ob, wftool):
     """
     # use catalog to retrieve review_state: getInfoFor causes recursion loop
     chain = list(ToolWorkflowChain(ob, wftool))
-    bc = getToolByName(ob, 'bika_catalog')
+    try:
+        bc = getToolByName(ob, 'bika_catalog')
+    except AttributeError:
+        logger.error(traceback.format_exc())
+        logger.error(
+            "Error getting 'bika_catalog' using 'getToolByName' with '{0}'"
+            " as context.".format(ob))
+        return chain
     proxies = bc(UID=ob.UID())
     if not proxies or proxies[0].review_state != 'sample_prep':
         return chain


### PR DESCRIPTION
Catching the error.
```

1491732412.20.361812639425 http://10.39.1.21/clients/client-181/base_view
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.client.analysisrequests, line 9, in __call__
  Module bika.lims.browser.client.views.analysisrequests, line 50, in __call__
  Module bika.lims.browser.analysisrequest.analysisrequests, line 1053, in __call__
  Module bika.lims.browser.bika_listing, line 786, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 171, in render
  Module fab3d2f037b26deeb63b9cab8cfeb7e2.py, line 520, in render
  Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 1172, in render_master
  Module 340eb0fb04d6cce4b1f1ed98ca09fe08.py, line 484, in render_content
  Module fab3d2f037b26deeb63b9cab8cfeb7e2.py, line 450, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1258, in contents_table
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 2799cb80de0fb1d4c9f068f66e6dd0cf.py, line 1743, in render
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1297, in get_workflow_actions
  Module Products.CMFPlone.WorkflowTool, line 84, in getTransitionsFor
  Module Products.CMFPlone.WorkflowTool, line 318, in getChainFor
  Module zope.component._api, line 107, in getMultiAdapter
  Module zope.component._api, line 120, in queryMultiAdapter
  Module zope.component.registry, line 238, in queryMultiAdapter
  Module zope.interface.adapter, line 532, in queryMultiAdapter
  Module bika.lims.workflow, line 231, in SamplePrepWorkflowChain
  Module Products.CMFCore.utils, line 10, in check_getToolByName
  Module Products.CMFCore.utils, line 120, in getToolByName
AttributeError: bika_catalog

 - Expression: "here/main_template/macros/master"
 - Filename:   ... ms/browser/analysisrequest/templates/analysisrequests.pt
 - Location:   (line 5: col 18)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "view/bika_listing/get_workflow_actions"
 - Filename:   ... a.lims/bika/lims/browser/templates/bika_listing_table.pt
 - Location:   (line 254: col 36)
 - Source:     ... fine="actions view/bika_listing/get_workflow_actions">
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  rows_only: False
               request: <instance - at 0x7f238ba73d88>
               table_only: False
               ViewResults: 1
               EditAnalyses: <NoneType - at 0x7ab150>
               toggle_cols: {...} (30)
               container: <ImplicitAcquisitionWrapper client-181 at 0x7f239023a0f0>
               specification: <NoneType - at 0x7ab150>
               wrapped_repeat: <SafeMapping - at 0x7f239ada1a48>
               traverse_subpath: <list - at 0x7f238253a878>
               column_list: <list - at 0x7f238b918098>
               template: <ViewPageTemplateFile - at 0x7f23a5459110>
               nosortclass: nosort
               review_state: {...} (6)
               translate: <function translate at 0x7f2381e57668>
               columns: {...} (32)
               klass: sortable column 
               tabindex: <generator tabindex at 0x7f23b48865f0>
               repeat: {...} (0)
               form_id: analysisrequests
               views: <ViewMapper - at 0x7f2381e50210>
               args: <tuple - at 0x7f238251b0d0>
               here: <ImplicitAcquisitionWrapper client-181 at 0x7f239023a0f0>
               portal: <ImplicitAcquisitionWrapper Plone at 0x7f2390209730>
               user: <ImplicitAcquisitionWrapper - at 0x7f23b51fccd0>
               nothing: <NoneType - at 0x7ab150>
               context: <ImplicitAcquisitionWrapper client-181 at 0x7f239023a0f0>
               nr_cols: 31
               roles: <list - at 0x7f2381e59128>
               default: <object - at 0x7f23d934cc40>
               modules: <instance - at 0x7f23ce3d0518>
               col: getClientSampleID
               review_state_id: default
               t: {...} (6)
               sm: <SecurityManager - at 0x7f239150ce60>
               target_language: <NoneType - at 0x7ab150>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f239b576140>
               options: {...} (0)
               loop: {...} (3)
               view: <BikaListingTable - at 0x7f2382530ad0>

```