### PR TITLE
NMRL-243 ValueError: time data '2016-05-10' does not match format '%Y-%m-%d %H:%M'

### DIFF
--- a/bika/lims/subscribers/bikasetup.py
+++ b/bika/lims/subscribers/bikasetup.py
@@ -38,6 +38,7 @@ def BikaSetupModifiedEventHandler(instance, event):
     mp(AddClient, roles, 1)
     mp(EditClient, roles, 1)
     # Set permissions at object level
+    # TODO-performance: We are allways reindexing all clients
     for obj in portal.clients.objectValues():
         mp = obj.manage_permission
         mp(AddClient, roles, 0)


### PR DESCRIPTION
```
ValueError: time data '2016-05-10' does not match format '%Y-%m-%d %H:%M'
(1 additional frame(s) were not displayed)
...
  File "ZPublisher/mapply.py", line 77, in mapply
    if debug is not None: return debug(object,args,context)
  File "ZPublisher/Publish.py", line 48, in call_object
    result=apply(object,args) # Type s<cr> to step into published object.
  File "home/nmrl/Plone/zeocluster/src/bika.health/bika/health/browser/analysisrequest/ajax.py", line 62, in __call__
    return BaseClass.__call__(self)
  File "home/nmrl/Plone/zeocluster/src/bika.lims/bika/lims/browser/analysisrequest/add.py", line 423, in __call__
    samp_date=datetime.datetime.strptime(samplingdate, "%Y-%m-%d %H:%M")
  File "python2.7/_strptime.py", line 325, in _strptime
    (data_string, format))

1491312198.80.378046494576 http://196.27.127.58/analysisrequests/analysisrequest_submit
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.ajax, line 62, in __call__
  Module bika.lims.browser.analysisrequest.add, line 423, in __call__
  Module _strptime, line 325, in _strptime
ValueError: time data '2016-05-10' does not match format '%Y-%m-%d %H:%M'
```