### PR TITLE
NMRL-261: Bika's DateTimeWidget. ValueError: <class 'exceptions.ValueError'>

### DIFF
--- a/bika/lims/browser/__init__.py
+++ b/bika/lims/browser/__init__.py
@@ -15,6 +15,7 @@ from bika.lims import logger
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.i18n import translate
 from time import strptime as _strptime
+import traceback
 
 
 def strptime(context, value):

--- a/bika/lims/browser/__init__.py
+++ b/bika/lims/browser/__init__.py
@@ -93,8 +93,11 @@ def ulocalized_time(time, long_format=None, time_only=None, context=None,
             time_str = _ut(time, long_format, time_only, context,
                            'bika', request)
         except:
+            err_msg = traceback.format_exc() + '\n'
+            logger.error(
+                err_msg +
+                "Error converting '{}' time to string.".format(time))
             time_str = ''
-
     return time_str
 
 


### PR DESCRIPTION
The error is not directly related.
```
1492788402.60.896600880986 http://10.67.1.6/patients/portal_factory/Patient/new/base_edit
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFPlone.FactoryTool, line 478, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 29, in _call
  Module Products.CMFFormController.ControllerBase, line 232, in getNext
  Module Products.CMFFormController.Actions.TraverseToAction, line 80, in __call__
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 91, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 32, in _call
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module Products.CMFCore.FSPageTemplate, line 237, in _exec
  Module Products.CMFCore.FSPageTemplate, line 177, in pt_render
  Module Products.PageTemplates.PageTemplate, line 87, in pt_render
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 411f8a301e69d5cb1ea259ef8f9e6f4f.py, line 1007, in render
  Module 411f8a301e69d5cb1ea259ef8f9e6f4f.py, line 822, in render_master
  Module 3247076587ffa571856cc6d035a3f328.py, line 1172, in render_master
  Module 3247076587ffa571856cc6d035a3f328.py, line 525, in render_content
  Module 411f8a301e69d5cb1ea259ef8f9e6f4f.py, line 812, in __fill_main
  Module 411f8a301e69d5cb1ea259ef8f9e6f4f.py, line 119, in render_main
  Module 328ae71276e99ef1c2e51b1610d56472.py, line 408, in render_body
  Module 202ba5c7fc9de1711c038a6733a3cb0a.py, line 195, in render_edit
  Module f39b830090c6085a833ef57f43e83dbb.py, line 557, in render_edit
  Module 202ba5c7fc9de1711c038a6733a3cb0a.py, line 128, in __fill_widget_body
  Module bika.lims.browser.widgets.datetimewidget, line 29, in ulocalized_time
  Module bika.lims.browser, line 65, in ulocalized_time
  Module Products.CMFPlone.i18nl10n, line 205, in ulocalized_time
  Module DateTime.DateTime, line 1551, in strftime
ValueError: <unprintable ValueError object>
```