### PR TITLE
sticker for worksheet

### DIFF
--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -23,7 +23,8 @@ class Sticker(BrowserView):
 
         In order to create a sticker inside an Add-on you have to create a
         directory inside the resource directory. Look at those examples:
-        - bika/addon/stickers/configure.zcml
+        This defines the resource folder to look for.
+        - path: bika/addon/stickers/configure.zcml
             ...
             **Defining stickers for samples, analysisrequests and partitions
             <plone:static
@@ -31,10 +32,15 @@ class Sticker(BrowserView):
               type="stickers"
               name="ADDON stickers" />
             ...
+        This is how to add general stickers for analysis requests, samples
+        and partitions.
         - bika/addon/stickers/templates/
             -- code_39_40x20mm.{css,pt}
             -- other_{sample,ar,partition}_stickers_...
 
+        This is the wasy to create specific sticker for a content type.
+        Note that in this case the directory '/worksheet' should contain the
+        sticker templates for worksheet objects.
         - bika/addon/stickers/templates/worksheet
             -- code_...mm.{css,pt}
             -- other_worksheet_stickers_...

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -205,3 +205,21 @@ class Sticker(BrowserView):
         req_items = req_items if req_items else self.context.getId()
         req = '%s?items=%s' % (self.request.URL, req_items)
         return req
+
+    def getClientFromCurrentItem(self):
+        """
+        This function tries to return the client from the current item.
+        :returns: A client object or None.
+        :rtype: ATContentType/NoneType
+        """
+        # 'current' will be an array such as [None, sample, sample_partition-1]
+        current = self.current_item
+        # Since the second item in the array is always a sample or reference
+        # sample, we can start getting it in order to get the client.
+        sample = current[1]
+        ars = sample.getAnalysisRequests()
+        if not ars:
+            return None
+        # Getting the real client object
+        client = ars[0].aq_parent.aq_inner
+        return client

--- a/bika/lims/browser/templates/stickers/readme.txt
+++ b/bika/lims/browser/templates/stickers/readme.txt
@@ -1,0 +1,24 @@
+Ho to create specific content type stickers
+===========================================
+
+If you want to create stickers for Content Type, first add the action in the
+Content Type xml definition file. You can found this files in
+bika/lims/profiles/default/types/*xml
+
+(Please, look at the 'url_expr' part.)
+
+```
+<action title="Stickers preview"
+        action_id="sticker_preview"
+        category="document_actions"
+        condition_expr=""
+        icon_expr="string:${object_url}/++resource++bika.lims.images/sticker_preview.png"
+        link_target="Stickers preview"
+        url_expr="string:${object_url}/sticker?filter_by_type=<<type_id>>"
+        i18n:attributes="title"
+        visible="True">
+    <permission value="View"/>
+</action>
+```
+
+Then create a new folder inside the stickers resource using the <<type_id>>.

--- a/bika/lims/browser/templates/stickers/worksheet/Code_39_40x20mm.css
+++ b/bika/lims/browser/templates/stickers/worksheet/Code_39_40x20mm.css
@@ -1,0 +1,36 @@
+/* 40x20mm sticker */
+.sticker {
+    font-family: Helvetica, Arial;
+    font-size:7pt;
+    /*
+    Total width:  38mm + 2x1mm (padding) = 40mm
+    Total height: 18mm + 2x1mm (padding) = 20mm
+    */
+    padding:1mm;
+    width: 38mm; min-width:38mm; max-width:38mm;
+    height: 20mm; min-height:20mm; max-height:20mm;
+}
+.sticker .worksheet-info table{
+    border-collapse:collapse;
+    margin: 1px 1px 1px 1px;
+    width:100%;
+}
+.sticker .worksheet-info table td {
+    border:none;
+}
+.barcode {
+    margin:0 auto;
+}
+.align-right {
+    text-align:right;
+}
+font-family: Helvetica, Arial;
+font-size:7pt;
+/* Total width: 1.5mm + 38mm + 1.5mm + 1.5mm + 38mm + 1.5mm = 82mm */
+width: 82mm;
+min-width:82mm;
+max-width:82mm;
+/* Total height: 1.5mm + 18mm + 1.5mm = 21mm */
+height:21mm;
+min-height:21mm;
+max-height:21mm;

--- a/bika/lims/browser/templates/stickers/worksheet/Code_39_40x20mm.pt
+++ b/bika/lims/browser/templates/stickers/worksheet/Code_39_40x20mm.pt
@@ -1,0 +1,34 @@
+<!--
+    Template used to render one barcode with dimensions of 40x20mm.
+
+    To retrieve the item, use view.current_item, that will return an array with
+    the following structure:
+
+    [None, AssignedAnalyst, workhseet]
+-->
+<tal:sticker define="
+    portal_state      context/@@plone_portal_state;
+    portal_url        portal_state/portal_url;
+    item              view/current_item;
+    analyst          python:item[1];
+    worksheet_id      python:item[2].getId();
+    ">
+
+    <!-- Barcode -->
+    <div class="barcode"
+        tal:attributes="data-id worksheet_id;"
+        data-code="code93"
+        data-barHeight="14"
+        data-addQuietZone="true"
+        data-showHRI="false">
+    </div>
+
+    <!-- Some additional info about the worksheet -->
+    <div class="worksheet-info">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tr>
+                <td tal:content="python: analyst"/>
+            </tr>
+        </table>
+    </div>
+</tal:sticker>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -190,8 +190,8 @@
               </tal:tick>
             </div>
             <tal:stickers repeat="sticker view/items">
-            <tal:sticker define="partid python:sticker[2].getId() if sticker else None;"
-                         condition="python:not partid or partid not in view.rendered_items">
+            <tal:sticker define="item_id python:sticker[2].getId() if sticker else None;"
+                         condition="python:not item_id or item_id not in view.rendered_items">
             <div class='sticker'
                  tal:content='structure python:view.renderItem()'></div>
             </tal:sticker>

--- a/bika/lims/profiles/default/types/Worksheet.xml
+++ b/bika/lims/profiles/default/types/Worksheet.xml
@@ -121,4 +121,28 @@
      <permission value="BIKA: View Log Tab"/>
  </action>
 
+<action title="Sticker"
+        action_id="sticker"
+        category="document_actions"
+        condition_expr=""
+        icon_expr="string:${object_url}/++resource++bika.lims.images/sticker_large.png"
+        link_target=""
+        url_expr="string:${object_url}/sticker?autoprint=1&amp;filter_by_type=worksheet"
+        i18n:attributes="title"
+        visible="True">
+   <permission value="View"/>
+</action>
+
+<action title="Stickers preview"
+        action_id="sticker_preview"
+        category="document_actions"
+        condition_expr=""
+        icon_expr="string:${object_url}/++resource++bika.lims.images/sticker_preview.png"
+        link_target="Stickers preview"
+        url_expr="string:${object_url}/sticker?filter_by_type=worksheet"
+        i18n:attributes="title"
+        visible="True">
+    <permission value="View"/>
+</action>
+
 </object>

--- a/bika/lims/vocabularies/__init__.py
+++ b/bika/lims/vocabularies/__init__.py
@@ -434,8 +434,7 @@ def getTemplates(bikalims_path, restype, filter_by_type=False):
     # Retrieve the templates from bika.lims add-on
     templates_dir = resource_filename("bika.lims", bikalims_path)
     tempath = os.path.join(templates_dir, '*.pt')
-    templates =\
-        ['bika.lims:' + os.path.split(x)[-1] for x in glob.glob(tempath)]
+    templates = [os.path.split(x)[-1] for x in glob.glob(tempath)]
 
     # Retrieve the templates from other add-ons
     for templates_resource in iterDirectoriesOfType(restype):
@@ -522,7 +521,7 @@ def getStickerTemplates(filter_by_type=False):
         Example: If filter_by_type=='worksheet', only *.tp files under a
         folder with this name will be displayed.
 
-        :param filter_by_type: 
+        :param filter_by_type:
         :type filter_by_type: string/bool.
         :returns: an array with the sticker templates available
     """


### PR DESCRIPTION
Accept first https://github.com/naralabs/bika.lims/pull/81/files

This pull request improves two things:
1) It allows to **created Content Type specific stickers** in an easy way using as much as possible the way this functionality was working. I prefered not to refactorize the class to change as few lines as possible.

Now, if you want to create stickers for Content Type, first add the action in the Content Type xml definition file. Look at the 'url_expr' part.
```
<action title="Stickers preview"
        action_id="sticker_preview"
        category="document_actions"
        condition_expr=""
        icon_expr="string:${object_url}/++resource++bika.lims.images/sticker_preview.png"
        link_target="Stickers preview"
        url_expr="string:${object_url}/sticker?filter_by_type=<<type_id>>"
        i18n:attributes="title"
        visible="True">
    <permission value="View"/>
</action>
```
Then create a new folder inside stickers resource using the <<type_id>>.

2) **The bases to add worksheet stickers.**