### PR TITLE
column getNumberOfVerifications

### DIFF
--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -83,6 +83,7 @@ _columns_list = [
     'getAnalystName',
     'hasAttachment',
     'getNumberOfRequiredVerifications',
+    'getNumberOfVerifications',
     'isSelfVerificationEnabled',
     'getSubmittedBy',
     'getVerificators',

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3.2.0.1704</version>
+  <version>3.2.0.1705</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -591,4 +591,11 @@
          handler="bika.lims.upgrade.v3_2_0_1704.upgrade"
          profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+         title="Upgrade to Bika LIMS 3.2.0.1705"
+         source="3.2.0.1704"
+         destination="3.2.0.1705"
+         handler="bika.lims.upgrade.v3_2_0_1705.upgrade"
+         profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -1,0 +1,40 @@
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import logger
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+import traceback
+import sys
+import transaction
+
+product = 'bika.lims'
+version = '3.2.0.1705'
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    ut = UpgradeUtils(portal)
+    ufrom = ut.getInstalledVersion(product)
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+                    product, ufrom, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
+
+    # Add getId column to bika_catalog
+    ut.addColumn(CATALOG_ANALYSIS_LISTING, 'getNumberOfVerifications')
+
+    # Refresh affected catalogs
+    ut.refreshCatalogs()
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
Column added in order to solve the error.

Upgrade step added.

```
AttributeError: getNumberOfVerifications
(5 additional frame(s) were not displayed)
...
  File "home/nmrl/Plone/zeocluster/src/bika.lims/bika/lims/browser/bika_listing.py", line 1295, in contents_table
    table = BikaListingTable(bika_listing = self, table_only = table_only)
  File "home/nmrl/Plone/zeocluster/src/bika.lims/bika/lims/browser/bika_listing.py", line 1456, in __init__
    folderitems = bika_listing.folderitems()
  File "home/nmrl/Plone/zeocluster/src/bika.lims/bika/lims/browser/analyses.py", line 930, in folderitems
    items = super(AnalysesView, self).folderitems(classic=False)
  File "home/nmrl/Plone/zeocluster/src/bika.lims/bika/lims/browser/bika_listing.py", line 1042, in folderitems
    item = self.folderitem(obj, results_dict, idx)
  File "home/nmrl/Plone/zeocluster/src/bika.lims/bika/lims/browser/analyses.py", line 804, in folderitem
    done = obj.getNumberOfVerifications

1494492537.910.108810583383 http://196.27.127.58/clients/client16-83/BP17-00044-R01/base_view
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.view, line 17, in __call__
  Module bika.lims.browser.analysisrequest.view, line 102, in __call__
  Module bika.lims.browser.bika_listing, line 1295, in contents_table
  Module bika.lims.browser.bika_listing, line 1456, in __init__
  Module bika.lims.browser.analyses, line 930, in folderitems
  Module bika.lims.browser.bika_listing, line 1042, in folderitems
  Module bika.lims.browser.analyses, line 804, in folderitem
AttributeError: getNumberOfVerifications
```