### PR TITLE
NMRL-289 AttributeError on Analysis Request submission: 'NoneType' object has no attribute 'getDepartment'

### DIFF
--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2943,7 +2943,7 @@ class AnalysisRequest(BaseFolder):
         """
         ans = [an.getObject() for an in self.getAnalyses()]
         depts = [an.getService().getDepartment() for an in ans if
-                 an.getService().getDepartment()]
+                 an.getService()]
         return set(depts)
 
     # TODO-performance: This function is very time consuming because


### PR DESCRIPTION
Fixes the following
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.ajax, line 62, in __call__
  Module bika.lims.browser.analysisrequest.add, line 479, in __call__
  Module bika.lims.utils.analysisrequest, line 78, in create_analysisrequest
  Module Products.Archetypes.BaseObject, line 629, in processForm
  Module Products.Archetypes.BaseObject, line 620, in _processForm
   - __traceback_info__: (<AnalysisRequest at /Plone/clients/client16-83/e5b7cda200bb54fb21fe391dd529d065>, <Field Analyses(analyses:rw)>, <bound method AnalysisRequest.setAnalyses of <AnalysisRequest at /Plone/clients/client16-83/e5b7cda200bb54fb21fe391dd529d065>>)
  Module Products.Archetypes.utils, line 130, in mapply
  Module Products.Archetypes.ClassGen, line 76, in generatedMutator
  Module bika.lims.browser.fields.aranalysesfield, line 181, in set
  Module bika.lims.utils.analysis, line 92, in create_analysis
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 89, in AfterTransitionEventHandler
  Module bika.lims.content.analysisrequest, line 3309, in workflow_script_no_sampling_workflow
  Module Products.Archetypes.CatalogMultiplex, line 118, in reindexObject
  Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 476, in catalog_object
  Module Products.ZCatalog.Catalog, line 340, in catalogObject
  Module Products.ZCatalog.Catalog, line 284, in updateMetadata
  Module Products.ZCatalog.Catalog, line 410, in recordify
  Module bika.lims.content.analysisrequest, line 2952, in getDepartmentUIDs
  Module bika.lims.content.analysisrequest, line 2946, in getDepartments
AttributeError: 'NoneType' object has no attribute 'getDepartment'
```