### PR TITLE
NMRL-292 KeyError on Samples view getSamplingDate

### DIFF
--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -356,7 +356,7 @@ class SamplesView(BikaListingView):
                          'getStorageLocation',
                          'SamplingDeviation',
                          'AdHoc',
-                         'getSamplingDate',
+                         'SamplingDate',
                          'DateReceived',
                          'getDateSampled',
                          'getSampler',


### PR DESCRIPTION
Traceback (innermost last):
  ```
Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 804, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 276, in render
  Module chameleon.template, line 171, in render
  Module 55a11edc405cdb42613f656390fc61d0.py, line 555, in render
  Module 3cd558b0ecf4f5881bee7d47c02abbda.py, line 1420, in render_master
  Module 3cd558b0ecf4f5881bee7d47c02abbda.py, line 578, in render_content
  Module 55a11edc405cdb42613f656390fc61d0.py, line 453, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1280, in contents_table
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 276, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 3ac7266b41a614bce2885ed0f7cd14d6.py, line 1674, in render
KeyError: 'getSamplingDate'

 - Expression: "view/contents_table"
 - Filename:   ... rc/bika.lims/bika/lims/browser/templates/bika_listing.pt
 - Location:   (line 48: col 31)
 - Source:     tal:content="structure view/contents_table"/>
                                      ^^^^^^^^^^^^^^^^^^^
 - Expression: "python:view.bika_listing.columns[column].get('sortable', True) and 'sortable column' or 'column'"
 - Filename:   ... a.lims/bika/lims/browser/templates/bika_listing_table.pt
 - Location:   (line 201: col 26)
 - Source:     ... python:view.bika_listing.columns[column].get('sortable', True) and 'sortable column' or 'column' ...
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  rows_only: False
               request: <instance - at 0x7fd07df65e60>
               table_only: False
               ViewResults: 1
               EditAnalyses: <NoneType - at 0x7b1070>
               toggle_cols: {...} (21)
               container: <ImplicitAcquisitionWrapper samples at 0x7fd0757e7f50>
               review_state_id: rejected
               specification: <NoneType - at 0x7b1070>
               wrapped_repeat: <SafeMapping - at 0x7fd071bb0418>
               traverse_subpath: <list - at 0x7fd075203680>
               column_list: <list - at 0x7fd07de6d050>
               template: <ViewPageTemplateFile - at 0x7fd086174fd0>
               nosortclass: nosort
               review_state: {...} (6)
               translate: <function translate at 0x7fd07cc5ed70>
               columns: {...} (24)
               klass: column 
               tabindex: <generator tabindex at 0x7fd08e0342d0>
               repeat: {...} (0)
               form_id: samples
               views: <ViewMapper - at 0x7fd07dac55d0>
               args: <tuple - at 0x7fd07ce18e50>
               here: <ImplicitAcquisitionWrapper samples at 0x7fd0757e7f50>
               portal: <ImplicitAcquisitionWrapper Plone at 0x7fd09cb51b40>
               user: <ImplicitAcquisitionWrapper - at 0x7fd078f9e4b0>
               nothing: <NoneType - at 0x7b1070>
               context: <ImplicitAcquisitionWrapper samples at 0x7fd0757e7f50>
               nr_cols: 24
               roles: <list - at 0x7fd0752033b0>
               default: <object - at 0x7fd0b6bd3c30>
               modules: <instance - at 0x7fd0abdc51b8>
               col: getClientSampleID
               column: getSamplingDate
               t: {...} (6)
               sm: <SecurityManager - at 0x7fd08e440a28>
               target_language: <NoneType - at 0x7b1070>
               root: <ImplicitAcquisitionWrapper Zope at 0x7fd0845fae10>
               options: {...} (0)
               loop: {...} (2)
               view: <BikaListingTable - at 0x7fd07d4ba190>
```