### PR TITLE
NMLR-260 Instrument's getReferenceAnalyses. bika.lims.instrument_qc_failures_viewlet fails

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -775,7 +775,7 @@ class AnalysesView(BikaListingView):
         resultdate = obj.getDateSampled \
             if obj.portal_type == 'ReferenceAnalysis' \
             else obj.getResultCaptureDate
-        duedate = obj.aq_parent.getExpiryDate \
+        duedate = obj.getExpiryDate \
             if obj.portal_type == 'ReferenceAnalysis' \
             else obj.getDueDate
         item['replace']['DueDate'] = \

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -153,7 +153,7 @@ function WorksheetAddQCAnalysesView() {
             }
             // tell the form handler which services were selected
             selected_service_uids = [];
-            $.each($("input:checked"), function(i,e){
+            $.each($(".worksheet_add_control_services .bika-listing-table input:checked"), function(i,e){
                 selected_service_uids.push($(e).val());
             });
             ssuids = selected_service_uids.join(",");

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -417,7 +417,7 @@ class ReferenceSamplesView(BikaListingView):
                 expirydate = DT2dt(exdate).replace(tzinfo=None)
                 if (datetime.today() > expirydate):
                     # Trigger expiration
-                    workflow.doActionFor(obj, 'expire')
+                    self.workflow.doActionFor(obj, 'expire')
                     item['review_state'] = 'expired'
                     item['obj'] = obj
 

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -195,7 +195,8 @@ Table cells for each column from in review_state's column list.
     <tal:comment replace="nothing"><!-- regular field --></tal:comment>
     <span tal:omit-tag="python:True"
         tal:condition="python:not isinstance(item[column], dict) and
-                        not (column == 'Result' and 'calculation' in item)">
+                        not (column == 'Result' and 'calculation' in item
+                        and item['calculation'])">
         <tal:comment replace="nothing"><!-- edit --></tal:comment>
         <input
             type="text" style="font-size: 100%"
@@ -217,18 +218,18 @@ Table cells for each column from in review_state's column list.
         <span
             tal:condition="python:not allow_edit and column == 'Result' and item.get('formatted_result', '')"
             tal:content="structure python:item['formatted_result']"
-            tal:attributes="class item/state_class"/>
+            tal:attributes="class item/state_class"></span>
         <span
             tal:condition="python:not allow_edit and column == 'Result' and not item.get('formatted_result', '')"
             tal:content="python:item.get('formatted_result', '')"
-            tal:attributes="class item/state_class"/>
+            tal:attributes="class item/state_class"></span>
         <tal:regularlabel condition="python:not allow_edit and column != 'Result'">
         <span tal:condition="python:item.get('structure',False)"
             tal:content="structure python:item[column] if item[column] is not None else ''"
-            tal:attributes="class item/state_class"/>
+            tal:attributes="class item/state_class"></span>
         <span tal:condition="python:not item.get('structure',False)"
             tal:content="python:item[column] if item[column] is not None else ''"
-            tal:attributes="class item/state_class"/>
+            tal:attributes="class item/state_class"></span>
         </tal:regularlabel>
         <input
             type="hidden"

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -195,8 +195,7 @@ Table cells for each column from in review_state's column list.
     <tal:comment replace="nothing"><!-- regular field --></tal:comment>
     <span tal:omit-tag="python:True"
         tal:condition="python:not isinstance(item[column], dict) and
-                        not (column == 'Result' and 'calculation' in item
-                        and item['calculation'])">
+                        not (column == 'Result' and item.get('calculation', False))">
         <tal:comment replace="nothing"><!-- edit --></tal:comment>
         <input
             type="text" style="font-size: 100%"
@@ -247,8 +246,7 @@ Table cells for each column from in review_state's column list.
     </span>
     <tal:comment replace="nothing"><!-- calculated result field. --></tal:comment>
     <span tal:omit-tag="python:True"
-        tal:condition="python:column == 'Result' and
-                            'calculation' in item">
+        tal:condition="python:column == 'Result' and item.get('calculation', False)">
         <span
             tal:attributes="
                 field string:formatted_result;

--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -54,6 +54,7 @@ _columns_list = [
     'getParentURL',
     'getAnalysisRequestURL',
     'getParentTitle',
+    'getParentUID',
     'getClientTitle',
     'getClientURL',
     'getAnalysisRequestTitle',
@@ -68,6 +69,7 @@ _columns_list = [
     'getRemarks',
     'getRetested',
     'getExpiryDate',
+    'getDateSampled',
     'getDueDate',
     'getReferenceResults',
     # Used in duplicated analysis objects

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -33,6 +33,9 @@ def upgrade(tool):
 
     # Add getId column to bika_catalog
     ut.addColumn(CATALOG_ANALYSIS_LISTING, 'getNumberOfVerifications')
+    # For reference samples
+    ut.addColumn(CATALOG_ANALYSIS_LISTING, 'getParentUID')
+    ut.addColumn(CATALOG_ANALYSIS_LISTING, 'getDateSampled')
 
     # Reindexing bika_catalog_analysisrequest_listing in order to obtain the
     # correct getDateXXXs


### PR DESCRIPTION
This PR **doesn't fix the error** because I couldn't reproduce it. I am still working on it. This PR fixes some related bug that I needed in order to resolve NMRL-260. 

This PR contains:
- Fixes in bika_listing and analyses listing when Reference Analyses are involved.
- Workflow tool is got one time only in bika_listing.
- JavaScript for Worksheet is more specific, the selector was getting all checkboxes in the page.
- The input of results were failing after bika_listing.py refactoring, some conditions in the template were not precise enough.
