### PR TITLE
NMRL-260 bika.lims.instrument qc failures viewlet

### DIFF
--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -166,7 +166,7 @@ class ReferenceAnalysesView(AnalysesView):
                 .format(obj.getId))
         elif wss and len(wss) == 1:
             # TODO-performance: We are getting the object here...
-            ws = wss[0].getObject()
+            ws = wss[0].getSourceObject()
             item['Worksheet'] = ws.Title()
             anchor = '<a href="%s">%s</a>' % (ws.absolute_url(), ws.Title())
             item['replace']['Worksheet'] = anchor
@@ -174,11 +174,12 @@ class ReferenceAnalysesView(AnalysesView):
             logger.warn(
                 'More than one Worksheet found for ReferenceAnalysis {}'
                 .format(obj.getId))
-        self.addToJSON(obj, service, item)
+        service_uid = obj.getServiceUID
+        self.addToJSON(obj, service_uid, item)
         return item
 
     # TODO-catalog: memoize here?
-    def addToJSON(self, analysis, service, item):
+    def addToJSON(self, analysis, service_uid, item):
         """ Adds an analysis item to the self.anjson dict that will be used
             after the page is rendered to generate a QC Chart
         """
@@ -189,9 +190,8 @@ class ReferenceAnalysesView(AnalysesView):
         anrows = trows.get(qcid, [])
         anid = '%s.%s' % (item['getReferenceAnalysesGroupID'], item['id'])
         rr = parent.getResultsRangeDict()
-        uid = service.UID()
-        if uid in rr:
-            specs = rr.get(uid, None)
+        if service_uid in rr:
+            specs = rr.get(service_uid, None)
             try:
                 smin = float(specs.get('min', 0))
                 smax = float(specs.get('max', 0))

--- a/bika/lims/browser/worksheet/views/analyses.py
+++ b/bika/lims/browser/worksheet/views/analyses.py
@@ -104,7 +104,7 @@ class AnalysesView(BaseView):
                 items[x]['DueDate'] = self.ulocalized_time(obj.getDueDate())
 
             items[x]['Order'] = ''
-            instrument = obj.getInstrument()
+            # instrument = obj.getInstrument()
             #items[x]['Instrument'] = instrument and instrument.Title() or ''
 
             new_items.append(item)

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -468,6 +468,65 @@ class ReferenceAnalysis(BaseContent):
         """
         return self.aq_parent.getReferenceResults()
 
+    def getInstrumentEntryOfResults(self):
+        """
+        It is a metacolumn.
+        Returns the same value as the service.
+        """
+        service = self.getService()
+        if not service:
+            return None
+        return service.getInstrumentEntryOfResults()
+
+    def getInstrumentUID(self):
+        """
+        It is a metacolumn.
+        Returns the same value as the service.
+        """
+        instrument = self.getInstrument()
+        if not instrument:
+            return None
+        return instrument.UID()
+
+    def getServiceDefaultInstrumentUID(self):
+        """
+        It is used as a metacolumn.
+        Returns the default service's instrument UID
+        """
+        service = self.getService()
+        if not service:
+            return None
+        ins = service.getInstrument()
+        if ins:
+            return ins.UID()
+        return ''
+
+    def getServiceDefaultInstrumentTitle(self):
+        """
+        It is used as a metacolumn.
+        Returns the default service's instrument UID
+        """
+        service = self.getService()
+        if not service:
+            return None
+        ins = service.getInstrument()
+        if ins:
+            return ins.Title()
+        return ''
+
+    def getServiceDefaultInstrumentURL(self):
+        """
+        It is used as a metacolumn.
+        Returns the default service's instrument UID
+        """
+        service = self.getService()
+        if not service:
+            return None
+        ins = service.getInstrument()
+        if ins:
+            return ins.absolute_url_path()
+        return ''
+
     def isVerifiable(self):
         """
         Checks it the current analysis can be verified. This is, its not a


### PR DESCRIPTION
- Missing methods in ReferenceAnalysis added.
- Cataloging tools in upgrade fodler have been improved, now the progress is shown. 
- upgrade/utils/refreshCatalogs only refresh catalogs with new columns, catalogs with new indexes are reindexed onyl.

Error:

```
rendering of plone.abovecontent in bika.lims.instrument_qc_failures_viewlet fails: -1755096285
Traceback (most recent call last):
  File "/home/lims/Plone/buildout-cache/eggs/plone.app.viewletmanager-2.0.9-py2.7.egg/plone/app/viewletmanager/manager.py", line 110, in render
    html.append(viewlet.render())
  File "/home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/instrument.py", line 743, in render
    self.get_failed_instruments()
  File "/home/lims/Plone/zeocluster/src/bika.lims/bika/lims/browser/instrument.py", line 723, in get_failed_instruments
    elif not i.isQCValid():
  File "/home/lims/Plone/zeocluster/src/bika.lims/bika/lims/content/instrument.py", line 537, in isQCValid
    for last in self.getLatestReferenceAnalyses():
  File "/home/lims/Plone/zeocluster/src/bika.lims/bika/lims/content/instrument.py", line 520, in getLatestReferenceAnalyses
    for ref in self.getReferenceAnalyses():
  File "/home/lims/Plone/zeocluster/src/bika.lims/bika/lims/content/instrument.py", line 713, in getReferenceAnalyses
    return [analysis for analysis in self.getAnalyses() \
  File "/home/lims/Plone/buildout-cache/eggs/Products.Archetypes-1.9.11-py2.7.egg/Products/Archetypes/ClassGen.py", line 56, in generatedAccessor
    return schema[name].get(self, **kw)
  File "/home/lims/Plone/buildout-cache/eggs/Products.Archetypes-1.9.11-py2.7.egg/Products/Archetypes/Field.py", line 1877, in get
    res = instance.getRefs(relationship=self.relationship)
  File "/home/lims/Plone/buildout-cache/eggs/Products.Archetypes-1.9.11-py2.7.egg/Products/Archetypes/Referenceable.py", line 81, in getRefs
    return [self._optimizedGetObject(b.targetUID) for b in brains]
  File "/home/lims/Plone/buildout-cache/eggs/Products.ZCatalog-2.13.27-py2.7.egg/Products/ZCatalog/Lazy.py", line 190, in __getitem__
    value = data[index] = self._func(self._seq[index])
  File "/home/lims/Plone/buildout-cache/eggs/Products.ZCatalog-2.13.27-py2.7.egg/Products/ZCatalog/Catalog.py", line 121, in __getitem__
    r=self._v_result_class(self.data[index]).__of__(aq_parent(self))
KeyError: -1755096285
```