### PR TITLE
NMRL-299 Replacement of FileField by BlobField

### DIFF
--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -186,7 +186,7 @@ class AnalysisRequestViewView(BrowserView):
             an_atts = analysis.getAttachment()
             for att in an_atts:
                 file_obj = att.getAttachmentFile()
-                fsize = file_obj.getSize() if file_obj else 0
+                fsize = file_obj.get_size() if file_obj else 0
                 if fsize < 1024:
                     fsize = '%s b' % fsize
                 else:

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -163,8 +163,10 @@ class AnalysisRequestViewView(BrowserView):
         ar_atts = self.context.getAttachment()
         analyses = self.context.getAnalyses(full_objects = True)
         for att in ar_atts:
-            file = att.getAttachmentFile()
-            fsize = file.getSize() if file else 0
+            file_obj = att.getAttachmentFile()
+            fsize = file_obj.get_size() if file_obj else 0
+            if isinstance(fsize, tuple):
+                fsize = 0
             if fsize < 1024:
                 fsize = '%s b' % fsize
             else:
@@ -173,8 +175,8 @@ class AnalysisRequestViewView(BrowserView):
                 'keywords': att.getAttachmentKeys(),
                 'analysis': '',
                 'size': fsize,
-                'name': file.filename,
-                'Icon': file.icon,
+                'name': file_obj.filename,
+                'Icon': file_obj.icon,
                 'type': att.getAttachmentType().Title() if att.getAttachmentType() else '',
                 'absolute_url': att.absolute_url(),
                 'UID': att.UID(),
@@ -183,8 +185,8 @@ class AnalysisRequestViewView(BrowserView):
         for analysis in analyses:
             an_atts = analysis.getAttachment()
             for att in an_atts:
-                file = att.getAttachmentFile()
-                fsize = file.getSize() if file else 0
+                file_obj = att.getAttachmentFile()
+                fsize = file_obj.getSize() if file_obj else 0
                 if fsize < 1024:
                     fsize = '%s b' % fsize
                 else:
@@ -193,8 +195,8 @@ class AnalysisRequestViewView(BrowserView):
                     'keywords': att.getAttachmentKeys(),
                     'analysis': analysis.Title(),
                     'size': fsize,
-                    'name': file.filename,
-                    'Icon': file.icon,
+                    'name': file_obj.filename,
+                    'Icon': file_obj.icon,
                     'type': att.getAttachmentType().Title() if att.getAttachmentType() else '',
                     'absolute_url': att.absolute_url(),
                     'UID': att.UID(),

--- a/bika/lims/content/arimport.py
+++ b/bika/lims/content/arimport.py
@@ -24,6 +24,7 @@ from collective.progressbar.events import ProgressState
 from collective.progressbar.events import UpdateProgressEvent
 from Products.Archetypes import atapi
 from Products.Archetypes.public import *
+from plone.app.blob.field import FileField as BlobFileField
 from Products.Archetypes.references import HoldingReference
 from Products.Archetypes.utils import addStatusMessage
 from Products.CMFCore.utils import getToolByName
@@ -47,7 +48,7 @@ import transaction
 
 _p = MessageFactory(u"plone")
 
-OriginalFile = FileField(
+OriginalFile = BlobFileField(
     'OriginalFile',
     widget=ComputedWidget(
         visible=False

--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -10,8 +10,10 @@
 from AccessControl import ClassSecurityInfo
 from Products.ATExtensions.ateapi import RecordsField
 from Products.Archetypes import atapi
-from Products.Archetypes.public import ReferenceField, FileField, \
-        StringField, Schema, BaseFolder
+from Products.Archetypes.public import ReferenceField
+from Products.Archetypes.public import StringField
+from Products.Archetypes.public import Schema
+from Products.Archetypes.public import BaseFolder
 from plone.app.blob.field import BlobField
 from Products.Archetypes.references import HoldingReference
 from bika.lims.config import PROJECTNAME

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -20,12 +20,6 @@ from bika.lims.utils import t
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((
-    ComputedField('RequestID',
-        expression = 'here.getRequestID()',
-        widget = ComputedWidget(
-            visible = True,
-        ),
-    ),
     FileField('AttachmentFile',
         widget = FileWidget(
             label=_("Attachment"),
@@ -52,23 +46,12 @@ schema = BikaSchema.copy() + Schema((
             label=_("Date Loaded"),
         ),
     ),
-    ComputedField('AttachmentTypeUID',
-        expression="context.getAttachmentType().UID() if context.getAttachmentType() else ''",
-        widget = ComputedWidget(
-            visible = False,
-        ),
-    ),
-    ComputedField('ClientUID',
-        expression = 'here.aq_parent.UID()',
-        widget = ComputedWidget(
-            visible = False,
-        ),
-    ),
 ),
 )
 
 schema['id'].required = False
 schema['title'].required = False
+
 
 class Attachment(BaseFolder):
     security = ClassSecurityInfo()
@@ -124,6 +107,16 @@ class Attachment(BaseFolder):
             return ar.getRequestID()
         else:
             return None
+
+    def getAttachmentTypeUID(self):
+        attachment_type = self.getAttachmentType()
+        if attachment_type:
+            return attachment_type.UID()
+        else:
+            return ''
+
+    def getClientUID(self):
+        return self.aq_parent.UID()
 
     def getAnalysis(self):
         """ Return the analysis to which this is linked """

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -9,6 +9,7 @@ from DateTime import DateTime
 from Products.ATExtensions.ateapi import DateTimeField, DateTimeWidget
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.Archetypes.public import Schema
+from plone.app.blob.field import FileField
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims.content.bikaschema import BikaSchema
@@ -16,7 +17,8 @@ from bika.lims.config import PROJECTNAME
 from bika.lims import bikaMessageFactory as _
 
 schema = BikaSchema.copy() + Schema((
-    atapi.FileField('AttachmentFile',
+    # It comes from blob
+    FileField('AttachmentFile',
         widget = atapi.FileWidget(
             label=_("Attachment"),
         ),

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -3,39 +3,35 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
 from AccessControl import ClassSecurityInfo
 from DateTime import DateTime
-from Products.ATExtensions.ateapi import DateTimeField, DateTimeWidget, RecordsField
+from Products.ATExtensions.ateapi import DateTimeField, DateTimeWidget
 from Products.Archetypes.config import REFERENCE_CATALOG
-from Products.Archetypes.public import *
-from Products.CMFCore.permissions import ListFolderContents, View
+from Products.Archetypes.public import Schema
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.config import PROJECTNAME
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((
-    FileField('AttachmentFile',
-        widget = FileWidget(
+    atapi.FileField('AttachmentFile',
+        widget = atapi.FileWidget(
             label=_("Attachment"),
         ),
     ),
-    ReferenceField('AttachmentType',
+    atapi.ReferenceField('AttachmentType',
         required = 0,
         allowed_types = ('AttachmentType',),
         relationship = 'AttachmentAttachmentType',
-        widget = ReferenceWidget(
+        widget = atapi.ReferenceWidget(
             label=_("Attachment Type"),
         ),
     ),
-    StringField('AttachmentKeys',
+    atapi.StringField('AttachmentKeys',
         searchable = True,
-        widget = StringWidget(
+        widget = atapi.StringWidget(
             label=_("Attachment Keys"),
         ),
     ),
@@ -53,7 +49,7 @@ schema['id'].required = False
 schema['title'].required = False
 
 
-class Attachment(BaseFolder):
+class Attachment(atapi.BaseFolder):
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -7,6 +7,7 @@ from AccessControl import ClassSecurityInfo
 from Products.ATContentTypes.content import schemata
 from Products.ATExtensions.ateapi import RecordsField
 from Products.Archetypes.atapi import *
+from plone.app.blob.field import FileField as BlobFileField
 from Products.Archetypes.references import HoldingReference
 from Products.CMFCore.permissions import View, ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
@@ -300,7 +301,7 @@ schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((
         )
     ),
 
-    FileField('InstallationCertificate',
+    BlobFileField('InstallationCertificate',
     schemata = 'Additional info.',
     widget = FileWidget(
         label=_("Installation Certificate"),

--- a/bika/lims/content/instrumentcertification.py
+++ b/bika/lims/content/instrumentcertification.py
@@ -7,6 +7,7 @@ from AccessControl import ClassSecurityInfo
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
 from Products.Archetypes.public import *
+from plone.app.blob.field import FileField as BlobFileField
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 from bika.lims.browser.widgets import DateTimeWidget, ReferenceWidget
@@ -118,7 +119,7 @@ schema = BikaSchema.copy() + Schema((
         ),
     ),
 
-    FileField('Document',
+    BlobFileField('Document',
         widget = FileWidget(
             label=_("Report upload"),
             description=_("Load the certificate document here"),

--- a/bika/lims/content/method.py
+++ b/bika/lims/content/method.py
@@ -7,6 +7,7 @@ from AccessControl import ClassSecurityInfo
 from Products.CMFCore.permissions import ModifyPortalContent, View
 from Products.CMFCore.utils import getToolByName
 from Products.Archetypes.public import *
+from plone.app.blob.field import FileField as BlobFileField
 from Products.Archetypes.references import HoldingReference
 from Products.ATExtensions.ateapi import RecordsField as RecordsField
 from bika.lims.browser.fields import HistoryAwareReferenceField
@@ -42,7 +43,7 @@ schema = BikaSchema.copy() + Schema((
             description=_("Technical description and instructions intended for analysts"),
         ),
     ),
-    FileField('MethodDocument',  # XXX Multiple Method documents please
+    BlobFileField('MethodDocument',  # XXX Multiple Method documents please
         widget = FileWidget(
             label=_("Method Document"),
             description=_("Load documents describing the method here"),

--- a/bika/lims/content/multifile.py
+++ b/bika/lims/content/multifile.py
@@ -5,6 +5,7 @@
 
 from zope.interface import implements
 from Products.Archetypes import atapi
+from plone.app.blob.field import FileField
 from Products.Archetypes.public import BaseContent
 from bika.lims.interfaces import IMultifile
 from bika.lims.content.bikaschema import BikaSchema
@@ -22,7 +23,7 @@ schema = BikaSchema.copy() + atapi.Schema((
         )
     ),
 
-    atapi.FileField('File',
+    FileField('File',
     required=1,
     widget = atapi.FileWidget(
         label=_("Document"),

--- a/bika/lims/content/report.py
+++ b/bika/lims/content/report.py
@@ -10,6 +10,7 @@ from DateTime import DateTime
 from Products.ATExtensions.ateapi import DateTimeField, DateTimeWidget
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.Archetypes.public import *
+from plone.app.blob.field import FileField as BlobFileField
 from Products.CMFCore.permissions import ListFolderContents, View
 from Products.CMFCore.utils import getToolByName
 from bika.lims.content.bikaschema import BikaSchema
@@ -19,7 +20,7 @@ from bika.lims.utils import t
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((
-    FileField('ReportFile',
+    BlobFileField('ReportFile',
         widget = FileWidget(
             label=_("Report"),
         ),
@@ -35,12 +36,6 @@ schema = BikaSchema.copy() + Schema((
         relationship = 'ReportClient',
         widget = ReferenceWidget(
             label=_("Client"),
-        ),
-    ),
-    ComputedField('ClientUID',
-        expression = 'here.getClient() and here.getClient().UID()',
-        widget = ComputedWidget(
-            visible = False,
         ),
     ),
 ),
@@ -63,6 +58,12 @@ class Report(BaseFolder):
     def current_date(self):
         """ return current date """
         return DateTime()
+
+    def getClientUID(self):
+        client = self.getClient()
+        if client:
+            return client.UID()
+        return ''
 
 
 atapi.registerType(Report, PROJECTNAME)

--- a/bika/lims/content/samplepoint.py
+++ b/bika/lims/content/samplepoint.py
@@ -5,6 +5,7 @@
 
 from AccessControl import ClassSecurityInfo
 from Products.Archetypes.public import *
+from plone.app.blob.field import FileField as BlobFileField
 from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
 from Products.CMFCore.permissions import View, ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
@@ -83,7 +84,7 @@ schema = BikaSchema.copy() + Schema((
                 "The default, unchecked, indicates 'grab' samples"),
         ),
     ),
-    FileField('AttachmentFile',
+    BlobFileField('AttachmentFile',
         widget = FileWidget(
             label=_("Attachment"),
         ),

--- a/bika/lims/upgrade/utils.py
+++ b/bika/lims/upgrade/utils.py
@@ -74,7 +74,7 @@ class BikaCustomQueryWalker(CustomQueryWalker):
             brains = brains[:limit]
         obj_num_total = len(brains)
         logger.info(
-            '{} objects will be migrated in {}'
+            '{} objects will be migrated walking through {}'
             .format(obj_num_total, catalog.id))
         counter = 0
         for brain in brains:

--- a/bika/lims/upgrade/utils.py
+++ b/bika/lims/upgrade/utils.py
@@ -80,7 +80,7 @@ class BikaCustomQueryWalker(CustomQueryWalker):
         for brain in brains:
             if counter % 100 == 0:
                 logger.info(
-                    'Progress: {} objects has been migrated out of {}'
+                    'Progress: {} objects have been migrated out of {}'
                     .format(counter, obj_num_total))
             try:
                 obj = brain.getObject()
@@ -104,7 +104,7 @@ class BikaCustomQueryWalker(CustomQueryWalker):
             counter += 1
             if obj_num_total == counter:
                 logger.info(
-                    'Progress: {} objects has been migrated out of {}'
+                    'Progress: {} objects have been migrated out of {}'
                     .format(counter, obj_num_total))
 
 

--- a/bika/lims/upgrade/utils.py
+++ b/bika/lims/upgrade/utils.py
@@ -3,6 +3,14 @@ from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from bika.lims import logger
 from bika.lims.catalog.catalog_utilities import addZCTextIndex
+from Products.contentmigration.walker import CustomQueryWalker
+from Products.contentmigration.migrator import BaseInlineMigrator
+from Products.contentmigration.common import HAS_LINGUA_PLONE
+from Products.Archetypes.interfaces import ISchema
+from plone.app.blob.interfaces import IBlobField
+from plone.app.blob.field import BlobWrapper
+from Acquisition import aq_base
+from transaction import savepoint
 # Interesting page for logging indexing process and others:
 # https://github.com/plone/Products.ZCatalog/tree/master/src/Products/ZCatalog
 # and
@@ -10,6 +18,171 @@ from bika.lims.catalog.catalog_utilities import addZCTextIndex
 import traceback
 import sys
 import transaction
+import logging
+
+
+LOG = logging.getLogger('contentmigration')
+
+
+def migrate_to_blob(context, portal_type, query={}, remove_old_value=True):
+    """
+    Migrates FileFields fields to blob ones for a given portal_type.
+    The wueries are done against 'portal_catalog', 'uid_catalog' and
+    'reference_catalog'
+
+    :param context: portal root object as context
+    :param query: an expression to filter the catalog by other filters than
+    the portal_type.
+    :param portal_type: The portal type name the migration is migrating *from*
+    """
+    migrator = makeMigrator(
+        context, portal_type, remove_old_value=remove_old_value)
+    walker = BikaCustomQueryWalker(context, migrator, query=query)
+    savepoint(optimistic=True)
+    walker.go()
+    return walker.getOutput()
+
+
+class BikaCustomQueryWalker(CustomQueryWalker):
+    """
+    Walker using portal_catalog and an optional custom query.
+    This class overrides the original one in order to log and inform
+    about the migration process.
+    """
+    additionalQuery = {}
+
+    def walk(self):
+        """
+        Walks around and returns all objects which needs migration
+        It does exactly the same as the original method, but add some
+        progress loggers.
+
+        :return: objects (with acquisition wrapper) that needs migration
+        :rtype: generator
+        """
+        catalog = self.catalog
+        query = self.additionalQuery.copy()
+        query['portal_type'] = self.src_portal_type
+        query['meta_type'] = self.src_meta_type
+
+        if HAS_LINGUA_PLONE and 'Language' in catalog.indexes():
+            query['Language'] = 'all'
+
+        brains = catalog(query)
+        limit = getattr(self, 'limit', False)
+        if limit:
+            brains = brains[:limit]
+        obj_num_total = len(brains)
+        logger.info(
+            '{} objects will be migrated in {}'
+            .format(obj_num_total, catalog.id))
+        counter = 0
+        for brain in brains:
+            if counter % 100 == 0:
+                logger.info(
+                    'Progress: {} objects has been migrated out of {}'
+                    .format(counter, obj_num_total))
+            try:
+                obj = brain.getObject()
+            except AttributeError:
+                LOG.error("Couldn't access %s" % brain.getPath())
+                continue
+
+            if self.callBefore is not None and callable(self.callBefore):
+                if self.callBefore(obj, **self.kwargs) == False:
+                    continue
+
+            try:
+                state = obj._p_changed
+            except:
+                state = 0
+            if obj is not None:
+                yield obj
+                # safe my butt
+                if state is None:
+                    obj._p_deactivate()
+            counter += 1
+            if obj_num_total == counter:
+                logger.info(
+                    'Progress: {} objects has been migrated out of {}'
+                    .format(counter, obj_num_total))
+
+
+# helper to build custom blob migrators for the given type. It is based on
+# the function defined in plone/app/blob/migrations.py with the same name.
+def makeMigrator(context, portal_type, remove_old_value=True):
+    """ generate a migrator for the given at-based portal type """
+    meta_type = portal_type
+
+    class BlobMigrator(BaseInlineMigrator):
+        """in-place migrator for archetypes based content that copies
+        file/image data from old non-blob fields to new fields with the same
+        name  provided by archetypes.schemaextender.
+
+        see `plone3 to 4 migration guide`__
+
+        .. __: https://plone.org/documentation/manual/upgrade-guide/version/upgrading-plone-3-x-to-4.0/updating-add-on-products-for-plone-4.0/use-plone.app.blob-based-blob-storage
+        """
+
+        src_portal_type = portal_type
+        src_meta_type = meta_type
+        dst_portal_type = portal_type
+        dst_meta_type = meta_type
+        fields = []
+
+        def getFields(self, obj):
+            if not self.fields:
+                # get the blob fields to migrate from the first object
+                for field in ISchema(obj).fields():
+                    if IBlobField.providedBy(field):
+                        self.fields.append(field.getName())
+            return self.fields
+
+        @property
+        def fields_map(self):
+            fields = self.getFields(None)
+            return dict([(name, None) for name in fields])
+
+        def migrate_data(self):
+            fields = self.getFields(self.obj)
+            for name in fields:
+                # access old field by not using schemaextender
+                oldfield = self.obj.schema[name]
+                is_imagefield = False
+                if hasattr(oldfield, 'removeScales'):
+                    # clean up old image scales
+                    is_imagefield = True
+                    oldfield.removeScales(self.obj)
+                value = oldfield.get(self.obj)
+
+                if not value:
+                    # no image/file data: don't copy it over to blob field
+                    # this way it's save to run migration multiple times w/o
+                    # overwriting existing data
+                    continue
+
+                if isinstance(aq_base(value), BlobWrapper):
+                    # already a blob field, no need to migrate it
+                    continue
+
+                # access new field via schemaextender
+                field = self.obj.getField(name)
+                field.getMutator(self.obj)(value)
+
+                if remove_old_value:
+                    # Remove data from old field to not end up with data
+                    # stored twice - in ZODB and blobstorage
+                    if is_imagefield:
+                        oldfield.set(self.obj, 'DELETE_IMAGE')
+                    else:
+                        oldfield.set(self.obj, 'DELETE_FILE')
+
+        def last_migrate_reindex(self):
+            # The original method checks the modification date in order to
+            # keep the old one, but we don't care about it.
+            self.obj.reindexObject()
+
+    return BlobMigrator
 
 
 class UpgradeUtils(object):

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -63,8 +63,8 @@ def upgrade(tool):
     # correct getDateXXXs
     ut.addIndexAndColumn(
         CATALOG_ANALYSIS_REQUEST_LISTING, 'getDateVerified', 'DateIndex')
-    # if CATALOG_ANALYSIS_REQUEST_LISTING not in ut.refreshcatalog:
-    #     ut.refreshcatalog.append(CATALOG_ANALYSIS_REQUEST_LISTING)
+    if CATALOG_ANALYSIS_REQUEST_LISTING not in ut.refreshcatalog:
+        ut.refreshcatalog.append(CATALOG_ANALYSIS_REQUEST_LISTING)
 
     # Refresh affected catalogs
     ut.refreshCatalogs()

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -78,10 +78,24 @@ def migareteFileFields(portal):
     This function walks over all attachment types and migrates their FileField
     fields.
     """
-    logger.info("Starting migration of FileField fields from Attachment.")
-    # Migarte only works for portal_catalog
-    migrate_to_blob(
-        portal,
-        portal_type='Attachment',
-        remove_old_value=True)
-    logger.info("Finished migration of FileField fields from Attachment.")
+    portal_types = [
+        "Attachment",
+        "ARImport",
+        "Instrument",
+        "InstrumentCertification",
+        "Method",
+        "Multifile",
+        "Report",
+        "SamplePoint"]
+    for portal_type in portal_types:
+        logger.info(
+            "Starting migration of FileField fields from {}."
+            .format(portal_type))
+        # Do the migration
+        migrate_to_blob(
+            portal,
+            portal_type=portal_type,
+            remove_old_value=True)
+        logger.info(
+            "Finished migration of FileField fields from {}."
+            .format(portal_type))

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -11,6 +11,7 @@ from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import VERSIONABLE_TYPES
 from Products.CMFCore.utils import getToolByName
+from bika.lims.upgrade.utils import migrate_to_blob
 import traceback
 import sys
 import transaction
@@ -32,7 +33,8 @@ def upgrade(tool):
         return True
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
-
+    # Migrating ataip.FileField to blob.FileField
+    migareteFileFields(portal)
     # Remove versionable types
     logger.info("Removing versionable types...")
     portal_repository = getToolByName(portal, 'portal_repository')
@@ -61,11 +63,25 @@ def upgrade(tool):
     # correct getDateXXXs
     ut.addIndexAndColumn(
         CATALOG_ANALYSIS_REQUEST_LISTING, 'getDateVerified', 'DateIndex')
-    if CATALOG_ANALYSIS_REQUEST_LISTING not in ut.refreshcatalog:
-        ut.refreshcatalog.append(CATALOG_ANALYSIS_REQUEST_LISTING)
+    # if CATALOG_ANALYSIS_REQUEST_LISTING not in ut.refreshcatalog:
+    #     ut.refreshcatalog.append(CATALOG_ANALYSIS_REQUEST_LISTING)
 
     # Refresh affected catalogs
     ut.refreshCatalogs()
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def migareteFileFields(portal):
+    """
+    This function walks over all attachment types and migrates their FileField
+    fields.
+    """
+    logger.info("Starting migration of FileField fields from Attachment.")
+    # Migarte only works for portal_catalog
+    migrate_to_blob(
+        portal,
+        portal_type='Attachment',
+        remove_old_value=True)
+    logger.info("Finished migration of FileField fields from Attachment.")


### PR DESCRIPTION
This pull request replaces all FileFields in the system to FileFields from Blob library.
An upgrade util has been created in order to migrate the content in those old FileFields to the new Blob ones.

Steps to migrate: 
- If you have a _bushy_ blobstorage: Just run the upgrade step and then pack the database.
- If you have a _lawn_ blobstorage: First migrate it following [this](https://stackoverflow.com/a/5604716/4799952), then run the upgrade step and pack.
- In some cases, blobstorage has both _bushy_ and _lawn_ layouts at the same time. This couldn't be possible and gives an error during the packing or blobstorage migration process. The best way to solve this could be to delete one of the files types, and make sure that _.layout_ file is in accordance with your selection. Then follow the previous steps.

The content_types with FileFields that has been migrated are:
        "Attachment",
        "ARImport",
        "Instrument",
        "InstrumentCertification",
        "Method",
        "Multifile",
        "Report",
        "SamplePoint"


**Warning!** While the migration process goes as expected, the following wired incident is happening:
Before migration:
- filestorage -> 9.1Gb
-- Data.fs -> 4.6Gb
- blobstorage -> 7.2Mb

After migration:
- filestorage -> 9.1Gb
-- Data.fs -> **4.6**Gb
- blobstorage -> 4.1Gb

After packing:
- filestorage -> 5.1Gb
-- Data.fs -> **465.1Mb**
- blobstorage ->  **54.9Mb**

The files are being duplicated even if in upgrade/utils.pyL173 the migrator is deleting the file in filestorage... WHY?!

**UPDATE** Packing will solve this.... But  packing fails...
```
2017-05-25 19:56:56 ERROR ZODB.DB packing
Traceback (most recent call last):
  File "/home/pau/dev/naralabs/nmrl/buildout-cache/eggs/ZODB3-3.10.5-py2.7-linux-x86_64.egg/ZODB/DB.py", line 812, in pack
    self.storage.pack(t, self.references)
  File "/home/pau/dev/naralabs/nmrl/buildout-cache/eggs/ZODB3-3.10.5-py2.7-linux-x86_64.egg/ZODB/blob.py", line 800, in pack
    self._packUndoing(packtime, referencesf)
  File "/home/pau/dev/naralabs/nmrl/buildout-cache/eggs/ZODB3-3.10.5-py2.7-linux-x86_64.egg/ZODB/blob.py", line 755, in _packUndoing
    remove_committed(filepath)
OSError: [Errno 21] Is a directory: '/home/pau/dev/naralabs/nmrl/zinstance/var/blobstorage/0x00/0x00'
2017-05-25 19:56:56 ERROR Zope.SiteErrorLog 1495735016.730.846204863413 http://localhost:8080/Control_Panel/Database/main/manage_pack
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module <string>, line 3, in manage_pack
  Module AccessControl.requestmethod, line 70, in _curried
  Module App.ApplicationManager, line 403, in manage_pack
  Module ZODB.DB, line 812, in pack
  Module ZODB.blob, line 800, in pack
  Module ZODB.blob, line 755, in _packUndoing
OSError: [Errno 21] Is a directory: '/home/pau/dev/naralabs/nmrl/zinstance/var/blobstorage/0x00/0x00'

```

**UPDATE2**
https://stackoverflow.com/questions/25733112/plone-migrate-blob-data-to-bushy-layout-ioerror-errno-21
https://stackoverflow.com/questions/5604321/how-and-why-to-set-the-layout-type-for-plone-app-blob-lawn-v-bushy