### PR TITLE
NMRL-301 Removing Html from ARReport

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -845,7 +845,6 @@ class AnalysisRequestPublishView(BrowserView):
             report.edit(
                 AnalysisRequest=ar.UID(),
                 Pdf=pdf_report,
-                Html=results_html,
                 Recipients=recipients
             )
             report.unmarkCreationFlag()

--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -29,8 +29,6 @@ schema = BikaSchema.copy() + Schema((
     ),
     BlobField('Pdf',
     ),
-    StringField('Html',
-    ),
     StringField('SMS',
     ),
     RecordsField('Recipients',

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -82,8 +82,12 @@ def removeHtmlFromAR(portal):
     uc = getToolByName(portal, 'uid_catalog')
     ar_reps = uc(portal_type='ARReport')
     f_name = 'Html'
+    counter = 0
     for ar in ar_reps:
         obj = ar.getObject()
         if hasattr(obj, f_name):
             delattr(obj, f_name)
-            print 'R'
+            counter += 1
+
+    logger.info("'Html' attribute has been removed from %d ARReport objects."
+                % counter)

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -64,8 +64,26 @@ def upgrade(tool):
     if CATALOG_ANALYSIS_REQUEST_LISTING not in ut.refreshcatalog:
         ut.refreshcatalog.append(CATALOG_ANALYSIS_REQUEST_LISTING)
 
+    # Deleting 'Html' field from ARReport objects.
+    removeHtmlFromAR(portal)
+
     # Refresh affected catalogs
     ut.refreshCatalogs()
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def removeHtmlFromAR(portal):
+    """
+    'Html' StringField has been deleted from ARReport Schema.
+    Now removing this attribute from old objects to save some memory.
+    """
+    uc = getToolByName(portal, 'uid_catalog')
+    ar_reps = uc(portal_type='ARReport')
+    f_name = 'Html'
+    for ar in ar_reps:
+        obj = ar.getObject()
+        if hasattr(obj, f_name):
+            delattr(obj, f_name)
+            print 'R'


### PR DESCRIPTION
From bika.lims.content.arreport, removed 'Html' field. 
The result will be a reduction of the database size and RAM consumption.
Note that there is the need of a migration script that walks thorugh all ARReport objects and remove the field.