### PR TITLE
NMRL-285_invalid_target_uid

### DIFF
--- a/bika/lims/skins/bika/bika_widgets/referencewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.js
@@ -31,6 +31,7 @@
 		save_UID_check();
 		check_UID_check();
 		check_missing_UID();
+
 		load_addbutton_overlays();
 		load_editbutton_overlays();
 	});
@@ -199,8 +200,17 @@ function check_missing_UID(){
     and the _uid hidden field are both blanked!
     */
 	fields = $(".ArchetypesReferenceWidget").children("input.referencewidget");
-    $.each(fields, function (index, value) {
-        debugger;
+    $.each(fields, function (index, field) {
+        var uid = $(this).attr("uid");
+        var fieldName = $(this).attr("fieldName");
+        var _uidinput = $("input[name^='" + fieldName + "_uid']");
+        var _uid = $(_uidinput).val();
+        if (!uid || uid == undefined || uid == ""
+            || !_uid || _uid == undefined || _uid == ""){
+                $(field).val("");
+                $(field).attr("uid", "");
+                $(_uidinput).val("");
+            }
     })
 }
 

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.js
@@ -193,25 +193,26 @@ function check_UID_check() {
 
 
 function check_missing_UID(){
-    /* This will remove the display value (the text-input value) if the
-    uid attribute OR the *_uid hidden field, have no value.
+	/* This will remove the display value (the text-input value) if the
+	uid attribute OR the *_uid hidden field, have no value.
 
-    If the display value is removed, then also verify that both the uid attr
-    and the _uid hidden field are both blanked!
-    */
-	fields = $(".ArchetypesReferenceWidget").children("input.referencewidget");
-    $.each(fields, function (index, field) {
-        var uid = $(this).attr("uid");
-        var fieldName = $(this).attr("fieldName");
-        var _uidinput = $("input[name^='" + fieldName + "_uid']");
-        var _uid = $(_uidinput).val();
-        if (!uid || uid == undefined || uid == ""
-            || !_uid || _uid == undefined || _uid == ""){
-                $(field).val("");
-                $(field).attr("uid", "");
-                $(_uidinput).val("");
-            }
-    })
+	If the display value is removed, then also verify that both the uid attr
+	and the _uid hidden field are both blanked!
+	*/
+	$.each($(".ArchetypesReferenceWidget").children("input.referencewidget"),
+		function (index, field) {
+			var uid = $(this).attr("uid");
+			var fieldName = $(this).attr("fieldName");
+			var _uidinput = $("input[name^='" + fieldName + "_uid']");
+			var _uid = $(_uidinput).val();
+			if (!uid || uid == undefined || uid == ""
+				|| !_uid || _uid == undefined || _uid == ""){
+					$(field).val("");
+					$(field).attr("uid", "");
+					$(_uidinput).val("");
+				}
+		}
+	)
 }
 
 function apply_button_overlay(button) {

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.js
@@ -30,6 +30,7 @@
 		});
 		save_UID_check();
 		check_UID_check();
+		check_missing_UID();
 		load_addbutton_overlays();
 		load_editbutton_overlays();
 	});
@@ -60,23 +61,6 @@ function referencewidget_lookups(elements) {
 		if (!options) {
 			continue;
 		}
-
-		// Prevent from saving previous record when input value is empty
-		// By default, a recordwidget input element gets an empty value
-		// when receives the focus, so the underneath values must be
-		// cleared too.
-		// var elName = $(element).attr("name");
-		// $("input[name='"+elName+"']").live("focusin", function(){
-		//  var fieldName = $(this).attr("name");
-		//  if($(this).val() || $(this).val().length===0){
-		//      var val = $(this).val();
-		//      var uid = $(this).attr("uid");
-		//      $(this).val("");
-		//      $(this).attr("uid", "");
-		//      $("input[name='"+fieldName+"_uid']").val("");
-		//      $(this).trigger("unselected", [val,uid]);
-		//  }
-		// });
 
 		options.select = function (event, ui) {
 			event.preventDefault();
@@ -204,6 +188,20 @@ function check_UID_check() {
 			$(this).attr('value', val_chk);
 		}
 	});
+}
+
+
+function check_missing_UID(){
+    /* This will remove the display value (the text-input value) if the
+    uid attribute OR the *_uid hidden field, have no value.
+
+    If the display value is removed, then also verify that both the uid attr
+    and the _uid hidden field are both blanked!
+    */
+	fields = $(".ArchetypesReferenceWidget").children("input.referencewidget");
+    $.each(fields, function (index, value) {
+        debugger;
+    })
 }
 
 function apply_button_overlay(button) {


### PR DESCRIPTION
Prevent ReferenceWidget from allowing invalid values.

These are usually present after the form is reloaded; the text
input retains it's value, but the uid attributes and hidden
fields have no value.