### PR TITLE
Some Schema's fields (as Keyword) for ReferenceAnalysis are empty

### DIFF
--- a/bika/lims/browser/worksheet/workflow.py
+++ b/bika/lims/browser/worksheet/workflow.py
@@ -216,7 +216,7 @@ class WorksheetWorkflowAction(WorkflowAction):
                         analysis.setInstrument(instruments[uid])
                         instrument = analysis.getInstrument()
                         instrument.addAnalysis(analysis)
-                        if analysis.portal_type == 'ReferenceAnalysis':
+                        if analysis.meta_type == 'ReferenceAnalysis':
                             instrument.setDisposeUntilNextCalibrationTest(False)
 
             # Need to save the method?

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -715,13 +715,13 @@ class Instrument(ATFolder):
         """ Add regular analysis (included WS QCs) to this instrument
             If the analysis has
         """
-        targetuid = analysis.getRawInstrument()
+        targetuid = analysis.getInstrumentUID()
         if not targetuid:
             return
         if targetuid != self.UID():
             raise Exception("Invalid instrument")
-        ans = self.getRawAnalyses() if self.getRawAnalyses() else []
-        ans.append(analysis.UID())
+        ans = self.getAnalyses() if self.getAnalyses() else []
+        ans.append(analysis)
         self.setAnalyses(ans)
         self.cleanReferenceAnalysesCache()
 
@@ -734,7 +734,7 @@ class Instrument(ATFolder):
         if targetuid != self.UID():
             raise Exception("Invalid instrument")
         uid = analysis.UID()
-        ans = [a for a in self.getRawAnalyses() if a != uid]
+        ans = [a for a in self.getAnalyses() if a.UID() != uid]
         self.setAnalyses(ans)
         self.cleanReferenceAnalysesCache()
 
@@ -820,7 +820,7 @@ class Instrument(ATFolder):
         prox = bac(portal_type=['Analysis', 'DuplicateAnalysis'],
                    review_state='to_be_verified')
         ans = [p.getObject() for p in prox]
-        return [a for a in ans if a.getRawInstrument() == self.UID()]
+        return [a for a in ans if a.getInstrumentUID() == self.UID()]
 
     def setImportDataInterface(self, values):
         """ Return the current list of import data interfaces

--- a/bika/lims/content/referencesample.py
+++ b/bika/lims/content/referencesample.py
@@ -347,7 +347,15 @@ class ReferenceSample(BaseFolder):
             if key not in analysis.Schema().keys():
                 continue
             val = service.getField(key).get(service)
-            analysis.getField(key).set(analysis, val)
+            # Campbell's mental note:never ever use '.set()' directly to a
+            # field. If you can't use the setter, then use the mutator in order
+            # to give the value. We have realized that in some cases using
+            # 'set' when the value is a string, it saves the value
+            # as unicode instead of plain string.
+            # analysis.getField(key).set(analysis, val)
+            mutator_name = analysis.getField(key).mutator
+            mutator = getattr(analysis, mutator_name)
+            mutator(val)
         analysis.setAnalysisService(service_uid)
         analysis.setReferenceType(reference_type)
         analysis.setInterimFields(interim_fields)

--- a/bika/lims/content/referencesample.py
+++ b/bika/lims/content/referencesample.py
@@ -321,10 +321,10 @@ class ReferenceSample(BaseFolder):
         Reference, with the type passed in and associates the newly
         created object to the Analysis Service passed in.
 
-        :param service_uid: The UID of the Analysis Service to be associated 
+        :param service_uid: The UID of the Analysis Service to be associated
         to the newly created Reference Analysis
         :type service_uid: A string
-        :param reference_type: type of ReferenceAnalysis, where 'b' is is  
+        :param reference_type: type of ReferenceAnalysis, where 'b' is is
         Blank and 'c' is Control
         :type reference_type: A String
         :returns: the UID of the newly created Reference Analysis
@@ -336,6 +336,18 @@ class ReferenceSample(BaseFolder):
         interim_fields = calc.getInterimFields() if calc else None
         interim_fields = interim_fields if interim_fields else []
         analysis = _createObjectByType("ReferenceAnalysis", self, id=tmpID())
+        # Copy all the values from the schema
+        # TODO Add Service as a param in ReferenceAnalysis constructor and do
+        #      this logic there instead of here
+        discard = ['id', ]
+        keys = service.Schema().keys()
+        for key in keys:
+            if key in discard:
+                continue
+            if key not in analysis.Schema().keys():
+                continue
+            val = service.getField(key).get(service)
+            analysis.getField(key).set(analysis, val)
         analysis.setAnalysisService(service_uid)
         analysis.setReferenceType(reference_type)
         analysis.setInterimFields(interim_fields)

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -392,6 +392,7 @@ def get_method_instrument_constraints(context, uids):
         s_mentry = analysis.getManualEntryOfResults()
         s_ientry = analysis.getInstrumentEntryOfResults()
         s_instrums = allowed_instruments if s_ientry else []
+        s_instrums = [instr.UID() for instr in s_instrums]
         a_dinstrum = analysis.getInstrument() if s_ientry else None
         s_methods = analysis.getAllowedMethods()
         s_dmethod = analysis.getMethod()


### PR DESCRIPTION
Some of the Schema fields from ReferenceAnalysis are empty because are not copied from the Analysis Service on creation.