### PR TITLE
UUIDIndexes need to be migarted to FieldIndexes

### DIFF
--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -49,7 +49,7 @@ _indexes_dict = {
     'getSampleConditionUID': 'FieldIndex',
     'getAnalysisRequestPrintStatus': 'FieldIndex',
     'getWorksheetUID': 'FieldIndex',
-    'getOriginalReflexedAnalysisUID': 'UUIDIndex',
+    'getOriginalReflexedAnalysisUID': 'FieldIndex',
 }
 # Defining the columns for this catalog
 _columns_list = [

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3.2.0.1705</version>
+  <version>3.2.0.1706</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -598,4 +598,10 @@
          handler="bika.lims.upgrade.v3_2_0_1705.upgrade"
          profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+         title="Upgrade to Bika LIMS 3.2.0.1706"
+         source="3.2.0.1705"
+         destination="3.2.0.1706"
+         handler="bika.lims.upgrade.v3_2_0_1706.upgrade"
+         profile="bika.lims:default"/>
 </configure>

--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -92,6 +92,9 @@ def upgrade(tool):
     # Adding two indexes in order to delete getBackreference in reflex rules
     reflex_rules(ut)
 
+    # Changing some indexes types
+    change_UUIDIndex(ut)
+
     # Refresh affected catalogs
     _cleanAndRebuildIfNeeded(portal, clean_and_rebuild)
     ut.refreshCatalogs()
@@ -834,4 +837,22 @@ def reflex_rules(ut):
         CATALOG_WORKSHEET_LISTING, 'getAnalysesUIDs', 'KeywordIndex')
     ut.addIndex(
         CATALOG_ANALYSIS_LISTING, 'getOriginalReflexedAnalysisUID', 'UUIDIndex'
+        )
+
+
+def change_UUIDIndex(ut):
+    """
+    UUIDIndex behaves like a FieldIndex, but can only store one document id
+    per value, so there's a 1:1 mapping from value to document id. An error
+    is logged if a different document id is indexed for an already taken value.
+
+    Some UUIDIndexes need to be migarted to FieldIndexes because more than one
+    field could contain the same UID, for instance
+    getOriginalReflexedAnalysisUID field.
+    """
+    ut.delIndex(CATALOG_ANALYSIS_LISTING, 'getOriginalReflexedAnalysisUID')
+    ut.addIndex(
+        CATALOG_ANALYSIS_LISTING,
+        'getOriginalReflexedAnalysisUID',
+        'FieldIndex'
         )

--- a/bika/lims/upgrade/v3_2_0_1706.py
+++ b/bika/lims/upgrade/v3_2_0_1706.py
@@ -1,0 +1,59 @@
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+from bika.lims import logger
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+
+product = 'bika.lims'
+version = '3.2.0.1706'
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    ut = UpgradeUtils(portal)
+    ufrom = ut.getInstalledVersion(product)
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ufrom, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
+
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile('profile-bika.lims:default', 'toolset')
+
+    # Updating lims catalogs if there is any change in them
+    logger.info("Updating catalogs if needed...")
+    change_UUIDIndex(ut)
+    ut.refreshCatalogs()
+    logger.info("Catalogs updated")
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True
+
+
+def change_UUIDIndex(ut):
+    """
+    UUIDIndex behaves like a FieldIndex, but can only store one document id
+    per value, so there's a 1:1 mapping from value to document id. An error
+    is logged if a different document id is indexed for an already taken value.
+
+    Some UUIDIndexes need to be migarted to FieldIndexes because more than one
+    field could contain the same UID, for instance
+    getOriginalReflexedAnalysisUID field.
+    """
+    ut.delIndex(CATALOG_ANALYSIS_LISTING, 'getOriginalReflexedAnalysisUID')
+    ut.addIndex(
+        CATALOG_ANALYSIS_LISTING,
+        'getOriginalReflexedAnalysisUID',
+        'FieldIndex'
+        )

--- a/bika/lims/upgrade/v3_2_0_1706.py
+++ b/bika/lims/upgrade/v3_2_0_1706.py
@@ -47,7 +47,7 @@ def change_UUIDIndex(ut):
     per value, so there's a 1:1 mapping from value to document id. An error
     is logged if a different document id is indexed for an already taken value.
 
-    Some UUIDIndexes need to be migarted to FieldIndexes because more than one
+    Some UUIDIndexes need to be migrated to FieldIndexes because more than one
     field could contain the same UID, for instance
     getOriginalReflexedAnalysisUID field.
     """


### PR DESCRIPTION
UUIDIndex behaves like a FieldIndex, but can only store one document id per value, so there's a 1:1 mapping from value to document id. An error  is logged if a different document id is indexed for an already taken value.

Some UUIDIndexes need to be migrated to FieldIndexes because more than one field could contain the same UID, for instance  getOriginalReflexedAnalysisUID field.

-> Upgrade step added in both: 06 and 05