### PR TITLE
NMRL-312 ValueError on results file import

### DIFF
--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -12,6 +12,7 @@ from Products.CMFPlone.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.widgets import DateTimeWidget
+from DateTime import DateTime
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from plone.app.blob.field import FileField
@@ -63,6 +64,10 @@ class Attachment(atapi.BaseFolder):
     def Title(self):
         """ Return the Id """
         return safe_unicode(self.getId()).encode('utf-8')
+
+    def current_date(self):
+        """ return current date """
+        return DateTime()
 
     def getRequest(self):
         """ Return the AR to which this is linked """


### PR DESCRIPTION
Missing function for default_method

```
ValueError: DateLoaded.default_method is neither a method of <class 'bika.lims.content.attachment.Attachment'> nor a callable
  File "home/lims/Plone/buildout-cache/eggs/Products.Archetypes-1.9.11-py2.7.egg/Products/Archetypes/BaseObject.py", line 144, in initializeArchetype
    self.setDefaults()
  File "home/lims/Plone/buildout-cache/eggs/Products.Archetypes-1.9.11-py2.7.egg/Products/Archetypes/BaseObject.py", line 420, in setDefaults
    self.Schema().setDefaults(self)
  File "home/lims/Plone/zeocluster/src/bika.lims/bika/lims/monkey/Schema.py", line 53, in setDefaults
    default = value if value else field.getDefault(instance)
  File "home/lims/Plone/buildout-cache/eggs/Products.Archetypes-1.9.11-py2.7.egg/Products/Archetypes/Field.py", line 672, in getDefault
    instance.__class__))

None
```