### PR TITLE
NMRL-313 AR State incosistence after upgrade step v3.2.0.1705

### DIFF
--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -517,6 +517,7 @@ class DashboardView(BrowserView):
         rstates = [k for k,v in statscount.items() if v==0]
         for o in outevo:
             for r in rstates:
-                del o[r]
+                if r in o:
+                    del o[r]
 
         return outevo

--- a/bika/lims/upgrade/v3_2_0_1706.py
+++ b/bika/lims/upgrade/v3_2_0_1706.py
@@ -9,6 +9,11 @@ from bika.lims import logger
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.utils import changeWorkflowState
+from bika.lims.workflow import getCurrentState
+from bika.lims.workflow import wasTransitionPerformed
+from plone.api.portal import get_tool
 
 product = 'bika.lims'
 version = '3.2.0.1706'
@@ -28,17 +33,81 @@ def upgrade(tool):
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ufrom, version))
 
-    setup = portal.portal_setup
-    setup.runImportStepFromProfile('profile-bika.lims:default', 'toolset')
-
     # Updating lims catalogs if there is any change in them
-    logger.info("Updating catalogs if needed...")
+    logger.info("Updating catalogs...")
     change_UUIDIndex(ut)
     ut.refreshCatalogs()
     logger.info("Catalogs updated")
 
+    # Fix ARs - Analyses in inconsistent state
+    # Transitioning Analysis Requests that were created before the upgrade
+    # step 17.05 to "received" state, their analyses remain in "sample_due"
+    # state. The analyses are therefore not available for assigning to
+    # worksheets or entering results.
+    # Note that after this issue happened, updateRoleMappings was added in
+    # v3.2.0.17.05 upgrade step as a safeguard. The fix in this upgrade should
+    # only work in those instances that were upgraded to 3.2.0.17.05 before
+    # updateRoleMappings was added (see commit 0931858)
+    fix_ar_analyses_statuses_inconsistences(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def fix_ar_analyses_statuses_inconsistences(portal):
+    logger.info("Fixing Analysis Request-Analyses statuses inconsistences...")
+
+    # Walkthrough 'received' analysis requests and find inconsistences:
+    # If Analysis Request's state is 'received', then:
+    # - Sample must be in received state too
+    # - Sample Partitions must be in received state too
+    # - Analyses must be in received state too
+    target_state = 'sample_received'
+    catalog = get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
+    brains = catalog(portal_type='AnalysisRequest', review_state=target_state)
+    for brain in brains:
+        analysisrequest = brain.getObject()
+        # Check Sample
+        sample = analysisrequest.getSample()
+        if sample:
+            sample_state = getCurrentState(sample)
+            if sample_state != target_state:
+                if not wasTransitionPerformed(sample, 'receive'):
+                    # Do force the state to received
+                    logger.info("{0}: '{1}' ({2}) -> {3}".format(
+                        'Sample', sample.getId(), sample_state, target_state))
+                    changeWorkflowState(sample, 'bika_sample_workflow',
+                                        target_state)
+
+            # Check Sample partitions
+            parts = sample.objectValues('SamplePartition')
+            for part in parts:
+                part_state = getCurrentState(part)
+                if part_state != target_state:
+                    if not wasTransitionPerformed(part, 'receive'):
+                        # Do force the state to received
+                        logger.info("{0}: '{1}' ({2}) -> {3}".format(
+                            'SamplePartition', part.getId(), part_state,
+                            target_state))
+                        changeWorkflowState(part, 'bika_sample_workflow',
+                                            target_state)
+
+        # Check analyses
+        analyses = analysisrequest.getAnalyses(full_objects=True)
+        for analysis in analyses:
+            an_state = getCurrentState(analysis)
+            if an_state != target_state:
+                if not wasTransitionPerformed(analysis, 'receive'):
+                    # Do force the state to received
+                    logger.info("{0}: '{1}' ({2}) -> {3}".format(
+                        'Analysis', analysis.getId(), an_state, target_state))
+                    changeWorkflowState(analysis, 'bika_analysis_workflow',
+                                        target_state)
+
+    # Force the update of role mappings
+    logger.info("Updating role mappings...")
+    wf = get_tool('portal_workflow')
+    wf.updateRoleMappings()
 
 
 def change_UUIDIndex(ut):


### PR DESCRIPTION
Force upgradeRoleMappings after workflow changes in upgrade step

Transitioning Analysis Requests that were created before the upgrade step 17.05 to "received" state, their analyses remain in "sample_due" state. The analyses are therefore not available for assigning to worksheets or entering results.

The system behaves correctly for newly created Analysis Requests. One possible explanation is that those old Analysis Requests (and their analyses) were not transitioned correctly. Instead, the state was set manually regardless of workflow definition, causing the analyses to have the "sample_due" state, but without the role mappings set, so the guard returns False when trying a new transition after the upgrade step.