### PR TITLE
NMRL-323 AttributeError during results publish: getObject

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -1313,7 +1313,7 @@ class AnalysisRequestDigester:
             contact = brains[0].getObject()
             data['fullname'] = contact.getFullname()
             data['email'] = contact.getEmailAddress()
-            sf = contact.getObject().getSignature()
+            sf = contact.getSignature()
             if sf:
                 data['signature'] = sf.absolute_url() + "/Signature"
         else:


### PR DESCRIPTION
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.publish, line 11, in __call__
  Module bika.lims.browser.analysisrequest.publish, line 115, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 769f8bd542972a8cf69f81f14ceb84d6.py, line 973, in render
  Module bika.lims.browser.analysisrequest.publish, line 156, in getAnalysisRequest
  Module bika.lims.browser.analysisrequest.publish, line 723, in __call__
  Module bika.lims.browser.analysisrequest.publish, line 973, in _ar_data
  Module bika.lims.browser.analysisrequest.publish, line 1316, in _reporter_data
AttributeError: getObject
```