### PR TITLE
NMRL-318 TypeError in Analysis Request' manage results view: object of type 'Missing.Value' has no len()

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -8,6 +8,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _
 from bika.lims import deprecated
+from bika.lims import logger
 from bika.lims.utils import t, dicts_to_dict, format_supsub
 from bika.lims.utils.analysis import format_uncertainty
 from bika.lims.browser.bika_listing import BikaListingView
@@ -422,6 +423,13 @@ class AnalysesView(BikaListingView):
                 self.categories.append((cat, cat_order))
         # Check for InterimFields attribute on our object,
         interim_fields = obj.getInterimFields
+        # TODO: This should never happen, we must ensure that interim_fields
+        # is always a list
+        if not isinstance(interim_fields, list):
+            logger.warn(
+                "InterimFields from {} isn't a list " +
+                "object. This should never happen".format(obj.getId))
+            interim_fields = []
         full_obj = None
         # kick some pretty display values in.
         for x in range(len(interim_fields)):

--- a/bika/lims/content/referencesample.py
+++ b/bika/lims/content/referencesample.py
@@ -333,8 +333,7 @@ class ReferenceSample(BaseFolder):
         rc = getToolByName(self, REFERENCE_CATALOG)
         service = rc.lookupObject(service_uid)
         calc = service.getCalculation()
-        interim_fields = calc.getInterimFields() if calc else None
-        interim_fields = interim_fields if interim_fields else []
+        interim_fields = calc.getInterimFields() if calc else []
         analysis = _createObjectByType("ReferenceAnalysis", self, id=tmpID())
         # Copy all the values from the schema
         # TODO Add Service as a param in ReferenceAnalysis constructor and do


### PR DESCRIPTION
- I added a preventive check. There is a TODO and a warning in order to track this issue in a future.

```
1497116344.10.0587537528111 http://10.0.0.191/clients/client-15/WB17-18940-R01/manage_results
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.manageresults, line 31, in __call__
  Module bika.lims.browser.analysisrequest.manage_results, line 55, in __call__
  Module bika.lims.browser.bika_listing, line 1294, in contents_table
  Module bika.lims.browser.bika_listing, line 1447, in __init__
  Module bika.lims.browser.analyses, line 943, in folderitems
  Module bika.lims.browser.bika_listing, line 1041, in folderitems
  Module bika.lims.browser.analyses, line 427, in folderitem
TypeError: object of type 'Missing.Value' has no len()
```