### PR TITLE
NMRL-296 ValueError on Patients View: No JSON object could be decoded

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -5,51 +5,34 @@
 
 """ Display lists of items in tables.
 """
-import json
-import re
-import urllib
 import copy
-from operator import itemgetter
-
-import App
-import pkg_resources
-import plone
-import transaction
+import json
+import traceback
 from AccessControl import getSecurityManager
-from Acquisition import aq_parent, aq_inner
+from Acquisition import aq_inner
+
+import plone
 from DateTime import DateTime
-from OFS.interfaces import IOrderedContainer
 from Products.AdvancedQuery import And, Or, MatchRegexp, Between, Generic, Eq
-from Products.Archetypes.config import REFERENCE_CATALOG
-from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone import PloneMessageFactory
-from Products.CMFPlone.utils import pretty_title_or_id, isExpired, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import PMF
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.browser import BrowserView
+from bika.lims.browser.bika_listing_filter_bar import BikaListingFilterBar
 from bika.lims.interfaces import IFieldIcons
-from bika.lims.utils import isActive, getHiddenAttributesForClass
-from bika.lims.utils import t, format_supsub
-from bika.lims.utils import to_utf8
 from bika.lims.utils import getFromString
+from bika.lims.utils import isActive, getHiddenAttributesForClass
+from bika.lims.utils import t
+from bika.lims.utils import to_utf8
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import skip
 from plone.app.content.browser import tableview
-from plone.app.content.browser.foldercontents import FolderContentsView, FolderContentsTable
-from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from zope.component import getAdapters
 from zope.component import getUtility
 from zope.component._api import getMultiAdapter
-from zope.i18nmessageid import MessageFactory
-from zope.interface import Interface
-from zope.interface import implements
-from bika.lims.browser.bika_listing_filter_bar import BikaListingFilterBar
-import types
-import traceback
 
 try:
     from plone.batching import Batch

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -771,14 +771,17 @@ class BikaListingView(BrowserView):
         self.request.response.setCookie(
             'bika_listing_filter_bar', None,  path='/', max_age=0)
         # Saving the filter bar values
-        try:
-            cookie_filter_bar = json.loads(cookie_filter_bar)
-        except ValueError:
-            err_msg = traceback.format_exc() + '\n'
-            logger.error(
-                err_msg +
-                "Error converting loading JSON object {} in {}."
-                .format(cookie_filter_bar, self.context))
+        if cookie_filter_bar is not None and cookie_filter_bar != '':
+            try:
+                cookie_filter_bar = json.loads(cookie_filter_bar)
+            except ValueError:
+                err_msg = traceback.format_exc() + '\n'
+                logger.error(
+                    err_msg +
+                    "Error decoding JSON object {} in {}."
+                    .format(cookie_filter_bar, self.context))
+                cookie_filter_bar = []
+        else:
             cookie_filter_bar = []
         # Creating a dict from cookie data
         cookie_data = {}

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -778,7 +778,8 @@ class BikaListingView(BrowserView):
                 err_msg = traceback.format_exc() + '\n'
                 logger.error(
                     err_msg +
-                    "Error decoding JSON object {} in {}."
+                    "Error decoding JSON object 'bika_listing_filter_bar' "
+                    "with value {} in {}."
                     .format(cookie_filter_bar, self.context))
                 cookie_filter_bar = []
         else:

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -49,6 +49,7 @@ from zope.interface import Interface
 from zope.interface import implements
 from bika.lims.browser.bika_listing_filter_bar import BikaListingFilterBar
 import types
+import traceback
 
 try:
     from plone.batching import Batch
@@ -787,8 +788,15 @@ class BikaListingView(BrowserView):
         self.request.response.setCookie(
             'bika_listing_filter_bar', None,  path='/', max_age=0)
         # Saving the filter bar values
-        cookie_filter_bar = json.loads(cookie_filter_bar) if\
-            cookie_filter_bar else ''
+        try:
+            cookie_filter_bar = json.loads(cookie_filter_bar)
+        except ValueError:
+            err_msg = traceback.format_exc() + '\n'
+            logger.error(
+                err_msg +
+                "Error converting loading JSON object {} in {}."
+                .format(cookie_filter_bar, self.context))
+            cookie_filter_bar = []
         # Creating a dict from cookie data
         cookie_data = {}
         for k, v in cookie_filter_bar:


### PR DESCRIPTION
- Imports optimized
- Check cookie value before decode
- Error catching for easier tracking in future errors

```
1496239046.970.519647166385 http://192.168.10.21/worksheets/base_view
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.worksheet.views.folder, line 268, in __call__
  Module bika.lims.browser.bika_listing, line 768, in __call__
  Module json, line 338, in loads
  Module json.decoder, line 366, in decode
  Module json.decoder, line 384, in raw_decode
ValueError: No JSON object could be decoded
```