### PR TITLE
Multiple use of instrument control in Worksheets

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -470,6 +470,11 @@ function WorksheetManageResultsView() {
             $(i_selector).prepend('<option value="">'+_('None')+'</option>');
         }
 
+        // Select the default instrument
+        if(is_ins_allowed(constraints[4])){
+           $(i_selector).val(constraints[4]);
+        }
+
         // Instrument selector visible?
         if (constraints[2] === 0) {
             $(i_selector).hide();

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -473,7 +473,7 @@ function WorksheetManageResultsView() {
         // Select the default instrument
         if(is_ins_allowed(constraints[4])){
            $(i_selector).val(constraints[4]);
-           $('table.bika-listing-table select.listing_select_entry[field="Instrument"][value!="'+iuid+'"] option[value="'+constraints[4]+'"]').prop('disabled', true);
+           $('table.bika-listing-table select.listing_select_entry[field="Instrument"][value!="'+constraints[4]+'"] option[value="'+constraints[4]+'"]').prop('disabled', true);
         }
 
         // Instrument selector visible?

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -473,6 +473,7 @@ function WorksheetManageResultsView() {
         // Select the default instrument
         if(is_ins_allowed(constraints[4])){
            $(i_selector).val(constraints[4]);
+           $('table.bika-listing-table select.listing_select_entry[field="Instrument"][value!="'+iuid+'"] option[value="'+constraints[4]+'"]').prop('disabled', true);
         }
 
         // Instrument selector visible?

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -470,11 +470,6 @@ function WorksheetManageResultsView() {
             $(i_selector).prepend('<option value="">'+_('None')+'</option>');
         }
 
-        // Select the default instrument
-        if(is_ins_allowed(constraints[4])){
-            $(i_selector).val(constraints[4]);
-        }
-
         // Instrument selector visible?
         if (constraints[2] === 0) {
             $(i_selector).hide();

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -467,14 +467,13 @@ function WorksheetManageResultsView() {
 
         // None option in instrument selector?
         if (constraints[3] == 1) {
-            $(i_selector).prepend('<option selected="selected" value="">'+_
-            ('None')
-            +'</option>');
+            $(i_selector).prepend('<option selected="selected" value="">'+_('None')+'</option>');
         }
 
         // Select the default instrument
         if(is_ins_allowed(constraints[4])){
            $(i_selector).val(constraints[4]);
+           // Disable this Instrument in the other Instrument SelectBoxes
            $('table.bika-listing-table select.listing_select_entry[field="Instrument"][value!="'+constraints[4]+'"] option[value="'+constraints[4]+'"]').prop('disabled', true);
         }
 

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -453,6 +453,12 @@ function WorksheetManageResultsView() {
             $(m_selector).show();
         }
 
+        // We are going to reload Instrument list.. Enable all disabled options from other Instrument lists which has the
+        // same value as old value of this Instrument Selectbox.
+        ins_old_val=$(i_selector).val();
+        if(ins_old_val && ins_old_val!=''){
+            $('table.bika-listing-table select.listing_select_entry[field="Instrument"][value!="'+ins_old_val+'"] option[value="'+ins_old_val+'"]').prop('disabled', false);
+        }
         // Populate instruments list
         $(i_selector).find('option').remove();
         if (constraints[7]) {

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -453,11 +453,11 @@ function WorksheetManageResultsView() {
 
         // Populate instruments list
         $(i_selector).find('option').remove();
-        console.log(constraints[7]);
         if (constraints[7]) {
             $.each(constraints[7], function(key, value) {
-                console.log(key+ ": "+value);
-                $(i_selector).append('<option value="'+key+'">'+value+'</option>');
+                if(is_ins_allowed(key)){
+                    $(i_selector).append('<option value="'+key+'">'+value+'</option>');
+                }
             });
         }
 
@@ -562,5 +562,25 @@ function WorksheetManageResultsView() {
             var muid = $(this).val();
             load_analysis_method_constraint(auid, muid);
         });
+    }
+
+    /**
+     * Check if the Instrument is allowed to appear in Instrument list of Analysis.
+     * Returns true if multiple use of an Instrument is enabled for assigned Worksheet Template or UID is not in selected Instruments
+     * @param {uid} ins_uid - UID of Instrument.
+     */
+    function is_ins_allowed(uid) {
+        var multiple_enabled = $("#instrument_multiple_use").attr('value');
+        if(multiple_enabled=='True'){
+            return true;
+        }else{
+            var i_selectors = $('select.listing_select_entry[field="Instrument"]');
+            for(i=0; i < i_selectors.length; i++){
+                if(i_selectors[i].value == uid){
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -463,6 +463,7 @@ function WorksheetManageResultsView() {
                     $(i_selector).append('<option value="'+key+'" disabled="true">'+value+'</option>');
                 }
             });
+            $(i_selector).change();
         }
 
         // None option in instrument selector?

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -467,7 +467,9 @@ function WorksheetManageResultsView() {
 
         // None option in instrument selector?
         if (constraints[3] == 1) {
-            $(i_selector).prepend('<option value="">'+_('None')+'</option>');
+            $(i_selector).prepend('<option selected="selected" value="">'+_
+            ('None')
+            +'</option>');
         }
 
         // Select the default instrument

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -463,7 +463,6 @@ function WorksheetManageResultsView() {
                     $(i_selector).append('<option value="'+key+'" disabled="true">'+value+'</option>');
                 }
             });
-            $(i_selector).change();
         }
 
         // None option in instrument selector?
@@ -472,7 +471,9 @@ function WorksheetManageResultsView() {
         }
 
         // Select the default instrument
-        $(i_selector).val(constraints[4]);
+        if(is_ins_allowed(constraints[4])){
+            $(i_selector).val(constraints[4]);
+        }
 
         // Instrument selector visible?
         if (constraints[2] === 0) {

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -242,6 +242,8 @@ function WorksheetManageResultsView() {
         loadRemarksEventHandlers();
 
         loadDetectionLimitsEventHandlers();
+
+        loadInstrumentEventHandlers();
     }
 
     function portalMessage(message) {
@@ -457,6 +459,8 @@ function WorksheetManageResultsView() {
             $.each(constraints[7], function(key, value) {
                 if(is_ins_allowed(key)){
                     $(i_selector).append('<option value="'+key+'">'+value+'</option>');
+                }else{
+                    $(i_selector).append('<option value="'+key+'" disabled="true">'+value+'</option>');
                 }
             });
         }
@@ -561,6 +565,26 @@ function WorksheetManageResultsView() {
             var auid = $(this).attr('uid');
             var muid = $(this).val();
             load_analysis_method_constraint(auid, muid);
+        });
+    }
+
+    /**
+     * If a new instrument is chosen for the analysis, disable this Instrument for the other analyses. Also, remove
+     * the restriction of previous Instrument of this analysis to be chosen in the other analyses.
+     */
+    function loadInstrumentEventHandlers() {
+        $('table.bika-listing-table select.listing_select_entry[field="Instrument"]').on('focus', function () {
+                // First, getting the previous value
+                previous = this.value;
+            }).change(function() {
+            var auid = $(this).attr('uid');
+            var iuid = $(this).val();
+            // Disable New Instrument for rest of the analyses
+            $('table.bika-listing-table select.listing_select_entry[field="Instrument"][value!="'+iuid+'"] option[value="'+iuid+'"]').prop('disabled', true);
+            // Enable previous Instrument everywhere
+            $('table.bika-listing-table select.listing_select_entry[field="Instrument"] option[value="'+previous+'"]').prop('disabled', false);
+            // Enable 'None' option as well.
+            $('table.bika-listing-table select.listing_select_entry[field="Instrument"] option[value=""]').prop('disabled', false);
         });
     }
 

--- a/bika/lims/browser/worksheet/templates/results.pt
+++ b/bika/lims/browser/worksheet/templates/results.pt
@@ -154,8 +154,9 @@
         </table>
     </tal:interimwide>
 
-    <span tal:replace="structure view/Analyses/contents_table"/>
 
+    <span tal:replace="structure view/Analyses/contents_table"/>
+    <input type="hidden" id = "instrument_multiple_use" tal:attributes="value python:context.getWorksheetTemplate().getEnableMultipleUseOfInstrument() if context.getWorksheetTemplate() else 'True';"/>
     <tal:remarks define="
         field python:context.Schema()['Remarks'];
         errors python:{};">

--- a/bika/lims/content/worksheettemplate.py
+++ b/bika/lims/content/worksheettemplate.py
@@ -100,7 +100,8 @@ schema = BikaSchema.copy() + Schema((
         widget=BooleanWidget(
             label=_("Enable Multiple Use of Instrument in Worksheets."),
             description=_("If unchecked, \
-                          Lab Managers won't be able to assign the same Instrument more than one Analyse.")
+                          Lab Managers won't be able to assign the same Instrument more than one Analyses while \
+                          creating a Worksheet.")
         )
     ),
 ))

--- a/bika/lims/content/worksheettemplate.py
+++ b/bika/lims/content/worksheettemplate.py
@@ -15,6 +15,8 @@ from bika.lims.browser.widgets import WorksheetTemplateLayoutWidget
 from bika.lims.config import ANALYSIS_TYPES, PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims import PMF, bikaMessageFactory as _
+from Products.Archetypes.atapi import BooleanField
+from Products.Archetypes.atapi import BooleanWidget
 from zope.interface import implements
 import sys
 
@@ -90,6 +92,16 @@ schema = BikaSchema.copy() + Schema((
         widget = ComputedWidget(
             visible = False,
         ),
+    ),
+    BooleanField(
+        'EnableMultipleUseOfInstrument',
+        default=True,
+        schemata="Description",
+        widget=BooleanWidget(
+            label=_("Enable Multiple Use of Instrument in Worksheets."),
+            description=_("If unchecked, \
+                          Lab Managers won't be able to assign the same Instrument more than one Analyse.")
+        )
     ),
 ))
 


### PR DESCRIPTION
For the case, if each Slot / Channel of any Instrument is created as an Instrument, it is necessary to prevent users to assign the same Instrument (which is actually Slot / Channel) to analyses more than once while generating Worksheet. 
In order to do that;
- Added a new Field to Worksheet Template content. So you users can Enable/ Disable Multiple use of the same Instrument more than once in a Worksheet.
- Added js control to Worksheet page to filter Instruments while they are retrieved from JSON and added to the Instruments list.