### PR TITLE
NMRL-330 IndexError while notifying rejection: list index out of range

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_mail.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_mail.pt
@@ -3,7 +3,8 @@
         portal_url nocall:context/portal_url;
         portal portal_url/getPortalObject;
         ar python:view.context;
-        reasons python:ar.getRejectionReasons()[0].get('selected',[]);
+        rej_widg    python:ar.getRejectionReasons();
+        reasons     python:ar.getRejectionReasons()[0].get('selected',[]) if rej_widg else []
         lab python:ar.bika_setup.laboratory;">
 
     <tal:multiplereasons condition="python:len(reasons)&gt;1">

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt
@@ -61,8 +61,8 @@
     alllabreas  python:ar.bika_setup.getRejectionReasons()[0];
     labreasons  python:[alllabreas[key] for key in alllabreas.keys() if key != 'checkbox'];
     client      python:ar.getClient();
-    reasons     python:ar.getRejectionReasons()[0].get('selected',[]);">
-
+    rej_widg    python:ar.getRejectionReasons();
+    reasons     python:ar.getRejectionReasons()[0].get('selected',[]) if rej_widg else [];">
     <div class="header">
         <h1 tal:content="lab/Title"></h1>
         <div class="header-logo">


### PR DESCRIPTION
Preventive condition added.

```
1497607973.080.780384292353 http://10.0.0.191/clients/client-247/WB17-21710/doActionForSample
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.sample, line 32, in __call__
  Module bika.lims.workflow, line 114, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 252, in AfterTransitionEventHandler
  Module bika.lims, line 205, in wrapper
  Module bika.lims.content.sample, line 917, in workflow_script_reject
  Module bika.lims.workflow.sample.events, line 138, in after_reject
  Module bika.lims.workflow, line 114, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 252, in AfterTransitionEventHandler
  Module bika.lims, line 205, in wrapper
  Module bika.lims.content.analysisrequest, line 3216, in workflow_script_reject
  Module bika.lims.workflow.analysisrequest.events, line 135, in after_reject
  Module bika.lims.utils.analysisrequest, line 304, in notify_rejection
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 2c0f861eefcb8f38254d9d9062c93130.py, line 209, in render
IndexError: list index out of range

 - Expression: "python:ar.getRejectionReasons()[0].get('selected',[])"
 - Filename:   ... analysisrequest/templates/analysisrequest_retract_pdf.pt
 - Location:   (line 64: col 7)
 - Source:     ... python:ar.getRejectionReasons()[0].get('selected',[]);">
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  modules: <instance - at 0x7f95b4378518>
               labreasons: <list - at 0x7f9568df1908>
               sample: <ImplicitAcquisitionWrapper WB17-21710 at 0x7f95551cb7d0>
               ar: <ImplicitAcquisitionWrapper WB17-21710-R01 at 0x7f94dd05e640>
               plone_view: <Plone plone at 0x7f94510bacd0>
               container: <ImplicitAcquisitionWrapper WB17-21710-R01 at 0x7f94dd05e640>
               wrapped_repeat: <SafeMapping - at 0x7f9450b802b8>
               portal_url: <ImplicitAcquisitionWrapper portal_url at 0x7f94deb79280>
               traverse_subpath: <list - at 0x7f95215aad88>
               template: <ViewPageTemplateFile - at 0x7f95547ea450>
               lab: <ImplicitAcquisitionWrapper laboratory at 0x7f94deb793c0>
               translate: <function translate at 0x7f944ac3ecf8>
               alllabreas: {...} (16)
               repeat: {...} (0)
               views: <ViewMapper - at 0x7f94501f0710>
               args: <tuple - at 0x7f95bf31e050>
               here: <ImplicitAcquisitionWrapper WB17-21710-R01 at 0x7f94dd05e640>
               portal: <ImplicitAcquisitionWrapper Plone at 0x7f953d893e10>
               user: <ImplicitAcquisitionWrapper - at 0x7f94ccdadd20>
               key: textfield-14
               nothing: <NoneType - at 0x7ab150>
               default: <object - at 0x7f95bf2f4c40>
               request: <instance - at 0x7f951923dab8>
               client: <ImplicitAcquisitionWrapper client-247 at 0x7f94dc974410>
               loop: {...} (0)
               context: <ImplicitAcquisitionWrapper WB17-21710-R01 at 0x7f94dd05e640>
               view: <AnalysisRequestRejectPdfView None at 0x7f94dde5f350>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f954f93f1e0>
               options: {...} (0)
               target_language: <NoneType - at 0x7ab150>
```