### PR TITLE
NMRL-349 AttributeError on upgrade.v3_2_0_1705: 'NoneType' object has no attribute 'aq_parent'

### DIFF
--- a/bika/lims/upgrade/v3_2_0_1705.py
+++ b/bika/lims/upgrade/v3_2_0_1705.py
@@ -561,7 +561,8 @@ def del_at_refs(rel):
         for ref_id, ref_obj in ref_dict.items():
             removed += 1
             size += 1
-            ref_obj.aq_parent.manage_delObjects([ref_id])
+            if ref_obj is not None:
+                ref_obj.aq_parent.manage_delObjects([ref_id])
     if removed:
         logger.info("Performed %s deletions" % removed)
     return removed


### PR DESCRIPTION
Preventive check added

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1034, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 54, in wrap_func_args
  Module bika.lims.upgrade.v3_2_0_1705, line 71, in upgrade
  Module bika.lims.upgrade.v3_2_0_1705, line 484, in BaseAnalysisRefactoring
  Module bika.lims.upgrade.v3_2_0_1705, line 564, in del_at_refs
AttributeError: 'NoneType' object has no attribute 'aq_parent'
```