### PR TITLE
NMRL-329 AttributeError on publish: getDigest

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -711,7 +711,8 @@ class AnalysisRequestDigester:
 
         # if AR was previously digested, use existing data (if exists)
         if not overwrite:
-            data = ar.getDigest()
+            # Prevent any error related with digest
+            data = ar.getDigest() if hasattr(ar, 'getDigest') else ''
             if data:
                 # Seems that sometimes the 'obj' is wrong in the saved data.
                 data['obj'] = ar
@@ -721,7 +722,8 @@ class AnalysisRequestDigester:
 
         # Set data to the AR schema field, and return it.
         data = self._ar_data(ar)
-        ar.setDigest(data)
+        if hasattr(ar, 'setDigest'):
+            ar.setDigest(data)
         return data
 
     def _schema_dict(self, instance, skip_fields=None, recurse=True):


### PR DESCRIPTION
It is a very strange error since the method exists.... Anyway, I added a preventive check there.

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.health.browser.analysisrequest.publish, line 11, in __call__
  Module bika.lims.browser.analysisrequest.publish, line 115, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 769f8bd542972a8cf69f81f14ceb84d6.py, line 973, in render
  Module bika.lims.browser.analysisrequest.publish, line 156, in getAnalysisRequest
  Module bika.lims.browser.analysisrequest.publish, line 714, in __call__
AttributeError: getDigest

 - Expression: "python:('ar_publish_body singlear %s' % ('ar-invalid' if hasattr(view.getAnalysisRequestObj(),'isInvalid') and view.getAnalysisRequestObj().isInvalid() else ('ar-provisional' if view.getAnalysisRequest()['prepublish']==True else '')))"
 - Filename:   ... ser/analysisrequest/templates/analysisrequest_publish.pt
 - Location:   (line 240: col 32)
 - Source:     ... python:('ar_publish_body singlear %s' % ('ar-invalid' if hasattr(view.getAnalysisRequestObj(),'isInvalid') and view.getAnalysisRequestObj().isInvalid() else ('ar-provisional' if view.getAnalysisRequest()['prepublish']==True else ''))) ...
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  default: <object - at 0x7f95bf2f4c40>
               repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f952508c790>
               views: <ViewMapper - at 0x7f9537875050>
               modules: <instance - at 0x7f95b4378518>
               args: <tuple - at 0x7f95bf31e050>
               here: <ImplicitAcquisitionWrapper analysisrequests at 0x7f951815ee10>
               portal: <ImplicitAcquisitionWrapper Plone at 0x7f9568a57d20>
               user: <ImplicitAcquisitionWrapper - at 0x7f951815ed70>
               nothing: <NoneType - at 0x7ab150>
               plone_view: <Plone plone at 0x7f952517e550>
               container: <ImplicitAcquisitionWrapper analysisrequests at 0x7f951815ee10>
               i: 0
               request: <instance - at 0x7f9524c0a170>
               wrapped_repeat: <SafeMapping - at 0x7f9562eccec0>
               portal_url: http://10.0.0.191
               traverse_subpath: <list - at 0x7f9584111320>
               loop: {...} (3)
               context: <ImplicitAcquisitionWrapper analysisrequests at 0x7f951815ee10>
               view: <AnalysisRequestPublishView publish at 0x7f9537875c90>
               portal_state: <PortalState plone_portal_state at 0x7f952517e5d0>
               translate: <function translate at 0x7f95138cf2a8>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f95a04e33c0>
               options: {...} (0)
               target_language: <NoneType - at 0x7ab150>
```