### PR TITLE
Fix AttributeError: getProvince and getDistrict in AnalysisRequests view

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -792,17 +792,6 @@ class AnalysisRequestsView(BikaListingView):
         # This variable will contain the full analysis request if there is
         # need to work with the full object instead of the brain
         full_object = None
-        # TODO-performance: quering every time not good
-        # extract province and district
-        client = self.portal_catalog(UID=obj.getClientUID)
-        if client:
-            item['Province'] = client[0].getProvince if\
-                client[0].getProvince else ''
-            item['District'] = client[0].getDistrict if\
-                client[0].getDistrict else ''
-        else:
-            item['Province'] = ''
-            item['District'] = ''
         item['Creator'] = self.user_fullname(obj.Creator)
         # If we redirect from the folderitems view we should check if the
         # user has permissions to medify the element or not.


### PR DESCRIPTION
In folderitem from AnalysisRequestView, the client was retrieved by querying portal_catalog just for getting the province and district, but there weren't such indexes in that catalog. In addition, the ARs catalog already had those two indexes, so there was no need to get the client first. Since both fields were declared in the columns schema, they are now automatically filled by bikallisting.

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.analysisrequests, line 1071, in __call__
  Module bika.lims.browser.bika_listing, line 808, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 1ee2209cad76db9278cd5726ac4bfad1.py, line 499, in render
  Module cf87da5b091a65499ac2b4dfafb7f66b.py, line 1172, in render_master
  Module cf87da5b091a65499ac2b4dfafb7f66b.py, line 484, in render_content
  Module 1ee2209cad76db9278cd5726ac4bfad1.py, line 429, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1289, in contents_table
  Module bika.lims.browser.bika_listing, line 1442, in __init__
  Module bika.lims.browser.analysisrequest.analysisrequests, line 782, in folderitems
  Module bika.lims.browser.bika_listing, line 1036, in folderitems
  Module bika.lims.browser.analysisrequest.analysisrequests, line 800, in folderitem
AttributeError: getProvince
```