### PR TITLE
Stickers to PDF and new sticker 2"x1" (50.8mm x 25.4mm) with barcode 3 of 9

### DIFF
--- a/bika/lims/browser/templates/stickers/Code_39_2ix1i.css
+++ b/bika/lims/browser/templates/stickers/Code_39_2ix1i.css
@@ -1,0 +1,51 @@
+/*
+Sticker Dimensions: 2 inch x 1 inch = 50.8mm x 25.4mm
+Sticker margins: 2mm
+*/
+.sticker {
+    margin:0 auto;
+    padding:2mm;
+    width: 46.8mm;
+    height: 21.4mm;
+    font-family: Helvetica, Arial;
+    font-size:7pt;
+}
+.sticker .barcode {
+    margin: 0 auto;
+    padding: 0 !important;
+    text-align:center;
+}
+.sticker .sample-id {
+    margin:0;
+    padding: 0mm 0mm 1mm 0mm;
+    text-align:center;
+}
+.sticker .analysisrequest-info table,
+.sticker .sampling-date-info table {
+    border-collapse:collapse;
+    margin: 1px 1px 1px 1px;
+    width:100%;
+}
+.sticker .analysisrequest-info table td,
+.sticker .sampling-date-info table td {
+    border:none;
+    text-align:center;
+}
+.barcode {
+    margin:0 auto;
+}
+.client-sample-id {
+    text-align:center;
+}
+
+@media print {
+    @page {
+        size:  50.8mm 25.4mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 50.8mm !important;
+        height: 25.4mm !important;
+        margin: 0mm !important;
+    }
+}

--- a/bika/lims/browser/templates/stickers/Code_39_2ix1i.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_2ix1i.pt
@@ -1,0 +1,72 @@
+<!--
+    Default template used to render one barcode small sticker
+
+    To retrieve the item, use view.current_item, that will return an array with
+    the following structure:
+
+    [analysis_request_object, sample_object, sample_partition_object]
+
+    Although sample_object (position 1 in the array) will never be None,
+    analysis_request_object can be None when
+    a) The user requested to render stickers for samples (instead of ARs) or
+    b) The user requested to render stickers for sample partitions or
+    c) The user requested to render stickers for reference samples.
+
+    If c), both analysis_request_object and sample_partition_object will be None
+-->
+<tal:sticker define="
+    portal_state      context/@@plone_portal_state;
+    portal_url        portal_state/portal_url;
+    item              view/current_item;
+    ar                python:item[0];
+    ar_id             python:ar.getId() if ar else '';
+    sample            python:item[1];
+    part              python:item[2];
+    partnr            python:part.getId().split('-')[1];
+    sampler           python:sample.getSampler();
+    sample_id         python:sample.getId();
+    sample_point      python:sample.getSamplePoint() and sample.getSamplePoint().Title() or '';
+    sample_type       python:sample.getSampleType().Title();
+    sd                python:sample.getSamplingDate();
+    sampling_date     python:sd.Date() if sd else '';
+    client_sample_id  python:sample.getClientSampleID();
+    preservation      python:part.getPreservation() and part.getPreservation().Title() or '';
+    container         python:part.getContainer() and part.getContainer().Title() or '';
+    date_sampled      python:sample.getDateSampled() and sample.getDateSampled().Date();
+    analyses          python:part.getAnalyses();
+    field_analyses    python:[analysis for analysis in analyses if analysis.getPointOfCapture()=='field'];
+    show_partitions   python:context.bika_setup.getShowPartitions();
+    smart_id          python:part.getId() if show_partitions else sample.getId();
+    hazardous         python:sample.getSampleType().getHazardous();">
+
+    <!-- Sample ID -->
+    <div class="sample-id">
+        <!--span tal:replace="string:${smart_id}"/-->
+        <img tal:condition="hazardous | nothing"
+             tal:attributes="src string:${portal_url}/++resource++bika.lims.images/hazardous.png"/>
+    </div>
+
+    <!-- Barcode -->
+    <div class="barcode"
+        tal:attributes="data-id smart_id;"
+        data-code="code39"
+        data-barHeight="14"
+        data-addQuietZone="true"
+        data-showHRI="false">
+    </div>
+
+    <!-- Some additional info about the sample -->
+    <div class="analysisrequest-info">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tr>
+                <td class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
+            </tr>
+            <tr>
+                <td class="sample-type" tal:content="python: sample_type"></td>
+            <tr>
+            <tr>
+                <td class="sampling-date" tal:content="python: sampling_date"></td>
+            <tr>
+        </table>
+    </div>
+</tal:sticker>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -151,8 +151,6 @@
 <body tal:attributes="onload        python:'this.print()' if view.request.get('autoprint', False) else '';
                       data-itemsurl python:view.getItemsURL();">
     <div id='sticker-preview-wrapper'>
-        <!-- Header of the preview. This will never be printed.
-             Container with preview options and buttons -->
         <div id="sticker-preview-header">
             <div id='options-handler'>
                 <div class='options-line'>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -108,7 +108,7 @@
         $(function(){
             $('#print-button').click(function(e) {
                 e.preventDefault();
-                window.print();
+                printPdf();
             });
             $('#cancel-button').click(function(e) {
                 e.preventDefault();
@@ -144,6 +144,26 @@
                     $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});
                     $('#sticker-rule').fadeIn();
                 });
+            }
+
+            function printPdf() {
+                var url = window.location.href;
+                // Get the stickers style
+                var style = $('#stickers-style').clone().wrap('<div>').parent().html();
+                var stickershtml = '';
+                // Get all stickers
+                $('#stickers-wrapper .sticker').each(function(e) {
+                    stickershtml += $(this).clone().wrap('<div>').parent().html();
+                });
+                // Generate the form (POST request to generate PDF)
+                var form = '<form action="'+url+'" name="topdf" method="post" style="display:none">' +
+                    '<textarea name="html"><div style="padding:0px;"></div>' +
+                    stickershtml + '</textarea>' +
+                    '<input type="hidden" name="pdf" value="1" />' +
+                    '<textarea name="style">' + style + '</textarea>' +
+                    '</form>';
+                $('body').html(form);
+                document.forms.topdf.submit();
             }
         });
     </script>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -90,7 +90,11 @@
         }
 
         @media print {
-            body {background-color:#fff;}
+            html, body {
+                margin: 0 !important;
+                padding: 0 !important;
+                background-color:#fff !important;
+            }
             #sticker-preview-header {display:none !important;}
             #stickers-wrapper { margin:0;}
             .sticker {


### PR DESCRIPTION
Machinery that generates a pdf when the user clicks the button "Print" in stickers preview.

If the page directive is added in the sticker's stylesheet, the system will generate a page for each sticker, otherwise will use the default (A4, letter) layout.

Also, a new sticker 2"x1" (50.8mm x 25.4mm) with barcode 3 of 9 has been added.

![captura de pantalla de 2017-06-27 17 48 09](https://user-images.githubusercontent.com/832627/27596769-d547706e-5b60-11e7-9bd1-225f7e87d106.png)
