### PR TITLE
Dynamic loading of allowed transitions in lists

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1062,7 +1062,7 @@ class BikaListingView(BrowserView):
         >>> browser.contents
         '...Water...'
         """
-
+        logger.warn("Using folderitems in classic mode, with objects wake-up")
         #self.contentsMethod = self.context.getFolderContents
         if not hasattr(self, 'contentsMethod'):
             self.contentsMethod = getToolByName(self.context, self.catalog)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -459,6 +459,8 @@ class BikaListingView(BrowserView):
         # Requests view checks bika_setup.getSamplingBarEnabledAnalysisRequests
         # to know if the functionality is activeated or not for its views.
         self.filter_bar_enabled = False
+        # Stores the translations of the statuses from the items displayed in
+        # this list. It value is set automatically in folderitems function.
         self.state_titles = {}
 
     @property
@@ -1042,7 +1044,7 @@ class BikaListingView(BrowserView):
 
         # Return a subset of results, if necessary
         if idxfrom and len(brains) > idxfrom:
-            return brains[limitfrom:]
+            return brains[idxfrom:]
         return brains
 
     def _folderitems(self, full_objects=False):

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -944,14 +944,18 @@ class BikaListingView(BrowserView):
             # Set states and state titles
             ptype = obj.portal_type
             for state_var, state in states.items():
+                results_dict[state_var] = state
                 st_title = self.state_titles.get(state, None)
                 if not st_title:
-                    st_title = self.workflow.getTitleForStateOnType(state,
-                                                                    ptype)
-                    if st_title:
-                        st_title = t(PMF(st_title))
-                        self.state_titles[state] = st_title
-                results_dict[state_var] = state
+                    try:
+                        st_title = self.workflow.getTitleForStateOnType(state,
+                                                                        ptype)
+                        if st_title:
+                            st_title = t(PMF(st_title))
+                            self.state_titles[state] = st_title
+                    except:
+                        logger.warning("Cannot obtain title for state {0} and "
+                                       "object {1}".format(state, obj.getId))
                 if st_title and state_var == obj.review_state:
                     results_dict['state_title'] = st_title
 

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -27,6 +27,7 @@ from bika.lims.utils import isActive, getHiddenAttributesForClass
 from bika.lims.utils import t
 from bika.lims.utils import to_utf8
 from bika.lims.workflow import doActionFor
+from bika.lims.workflow import getAllowedTransitions
 from bika.lims.workflow import skip
 from plone.app.content.browser import tableview
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -1202,6 +1203,8 @@ class BikaListingView(BrowserView):
                         state, obj.portal_type)
                 results_dict[state_var] = state
             results_dict['state_title'] = st_title
+
+            results_dict['valid_transitions'] = getAllowedTransitions(obj)
 
             # extra classes for individual fields on this item { field_id : "css classes" }
             results_dict['class'] = {}

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -245,10 +245,16 @@ function BikaListingTableView() {
 		var allowed_transitions = [];
 		var hidden_transitions = $(blst).find('input[type="hidden"][id="hide_transitions"]');
 		hidden_transitions = $(hidden_transitions).val().split(',');
+		var restricted_transitions = $(blst).find('input[type="hidden"][id="restricted_transitions"]');
+		restricted_transitions = $(restricted_transitions).val().split(',');
 		var checked = $(blst).find("input[type='checkbox'][id*='_cb_']:checked");
 		$(checked).each(function(e) {
 			var transitions = $(this).attr('data-valid_transitions');
 			transitions = transitions.split(',');
+			// Do not want transitions other than those defined in bikalisting
+			transitions = transitions.filter(function(el) {
+				return restricted_transitions.indexOf(el) != -1;
+			});
 			// Do not show hidden transitions
 			transitions = transitions.filter(function(el) {
 				return hidden_transitions.indexOf(el) == -1;
@@ -261,6 +267,11 @@ function BikaListingTableView() {
 			}
 			allowed_transitions = transitions;
 		});
+		// Sort the transitions in accordance with bikalisting settings
+		allowed_transitions = restricted_transitions.filter(function(v) {
+		    return allowed_transitions.includes(v);
+		});
+
 		// Generate the action buttons
 		var buttonspane = $(blst).find('span.workflow_action_buttons');
 		$(buttonspane).html('');

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -246,31 +246,40 @@ function BikaListingTableView() {
 		var hidden_transitions = $(blst).find('input[type="hidden"][id="hide_transitions"]');
 		hidden_transitions = $(hidden_transitions).val().split(',');
 		var restricted_transitions = $(blst).find('input[type="hidden"][id="restricted_transitions"]');
-		restricted_transitions = $(restricted_transitions).val().split(',');
+		restricted_transitions = $(restricted_transitions).val();
+		restricted_transitions = restricted_transitions === '' ? [] : restricted_transitions.split(',');
 		var checked = $(blst).find("input[type='checkbox'][id*='_cb_']:checked");
 		$(checked).each(function(e) {
 			var transitions = $(this).attr('data-valid_transitions');
+			console.log(transitions);
 			transitions = transitions.split(',');
-			// Do not want transitions other than those defined in bikalisting
-			transitions = transitions.filter(function(el) {
-				return restricted_transitions.indexOf(el) != -1;
-			});
+			if (restricted_transitions.length > 0) {
+				// Do not want transitions other than those defined in bikalisting
+				transitions = transitions.filter(function(el) {
+					return restricted_transitions.indexOf(el) != -1;
+				});
+			}
+			console.log(transitions);
 			// Do not show hidden transitions
 			transitions = transitions.filter(function(el) {
 				return hidden_transitions.indexOf(el) == -1;
 			});
+			console.log(transitions);
 			// We only want the intersection within all selected items
 			if (allowed_transitions.length > 0) {
 				transitions = transitions.filter(function(el) {
 					return allowed_transitions.indexOf(el) != -1;
 				});
 			}
+			console.log(transitions);
 			allowed_transitions = transitions;
 		});
-		// Sort the transitions in accordance with bikalisting settings
-		allowed_transitions = restricted_transitions.filter(function(v) {
-		    return allowed_transitions.includes(v);
-		});
+		if (restricted_transitions.length > 0) {
+			// Sort the transitions in accordance with bikalisting settings
+			allowed_transitions = restricted_transitions.filter(function(v) {
+			    return allowed_transitions.includes(v);
+			});
+		}
 
 		// Generate the action buttons
 		var buttonspane = $(blst).find('span.workflow_action_buttons');

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -243,10 +243,17 @@ function BikaListingTableView() {
 	function render_transition_buttons(blst) {
 		"use strict";
 		var allowed_transitions = [];
+		var hidden_transitions = $(blst).find('input[type="hidden"][id="hide_transitions"]');
+		hidden_transitions = $(hidden_transitions).val().split(',');
 		var checked = $(blst).find("input[type='checkbox'][id*='_cb_']:checked");
 		$(checked).each(function(e) {
 			var transitions = $(this).attr('data-valid_transitions');
 			transitions = transitions.split(',');
+			// Do not show hidden transitions
+			transitions = transitions.filter(function(el) {
+				return hidden_transitions.indexOf(el) == -1;
+			});
+			// We only want the intersection within all selected items
 			if (allowed_transitions.length > 0) {
 				transitions = transitions.filter(function(el) {
 					return allowed_transitions.indexOf(el) != -1;

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -3,15 +3,17 @@
  */
 function BikaListingTableView() {
 
-	var that = this
+	var that = this;
+	// To keep track if a transitions loading is taking place atm
+	var loading_transitions = false;
 
 	// Entry-point method for AnalysisServiceEditView
 	that.load = function () {
 
 		column_header_clicked()
-		select_one_clicked()
-		select_all_clicked()
-		manage_select_all_state()
+		load_transitions();
+		select_one_clicked();
+		select_all_clicked();
 		listing_string_input_keypress()
 		listing_string_select_changed()
 		pagesize_change()
@@ -72,6 +74,7 @@ function BikaListingTableView() {
 						$('#' + formid + ' a.bika_listing_show_more').hide();
 						console.log(e);
 					}
+					load_transitions();
 				}).fail(function () {
 					$('#'+formid+' a.bika_listing_show_more').hide();
 					console.log("bika_listing_show_more failed");
@@ -147,81 +150,122 @@ function BikaListingTableView() {
 		})
 	}
 
-	function show_or_hide_transition_buttons() {
-		// Get all transitions for all items, into all_valid_transitions
-		var all_valid_transitions = [] // array of arrays
-		var checked = $("input[name='uids:list']:checked")
-		if (checked.length == 0){
-			$("input[workflow_transition]").hide()
-			return
+	/**
+	* Fetch allowed transitions for all the objects listed in bika_listing and
+	* sets the value for the attribute 'data-valid_transitions' for each check
+	* box next to each row.
+	* The process requires an ajax call, so the function keeps checkboxes
+	* disabled until the allowed transitions for the associated object are set.
+	*/
+	function load_transitions() {
+		"use strict";
+		if (loading_transitions) {
+			return;
 		}
-		for(var i=0; i<checked.length; i++){
-			all_valid_transitions.push($(checked[i]).attr("data-valid_transitions").split(","))
+		loading_transitions = true;
+		var uids = [];
+		var checkall = $("input[id*='select_all']");
+		$(checkall).hide();
+		var wo_trans = $("input[type='checkbox'][id*='_cb_'][data-valid_transitions='']");
+		$(wo_trans).hide();
+		$(wo_trans).each(function(e){
+			uids.push($(this).val());
+		});
+		if (uids.length > 0) {
+			var request_data = {
+				_authenticator: $("input[name='_authenticator']").val(),
+				uid:  $.toJSON(uids),};
+			window.jsonapi_cache = window.jsonapi_cache || {};
+			$.ajax({
+				type: "POST",
+				dataType: "json",
+				url: window.portal_url + "/@@API/allowedTransitionsFor_many",
+				data: request_data,
+				success: function(data) {
+					if ('transitions' in data) {
+						for (var i = 0; i < data.transitions.length; i++) {
+							var uid = data.transitions[i].uid;
+							var trans = data.transitions[i].transitions;
+							var el = $("input[type='checkbox'][id*='_cb_'][value='"+uid+"']");
+							el.attr('data-valid_transitions', trans.join(','));
+							$(el).show();
+						}
+						$("input[id*='select_all']").fadeIn();
+					}
+				}
+			});
 		}
-		// intersect values from all arrays in all_valid_transitions
-		var valid_transitions = all_valid_transitions.shift().filter(function (v) {
-		    return all_valid_transitions.every(function (a) {
-		        return a.indexOf(v) !== -1;
-		    })
-		})
-		// Hide all buttons except the ones listed as valid.
-		$.each($("input[workflow_transition='yes']"), function (i, e) {
-			if($.inArray($(e).attr('transition'), valid_transitions) == -1){
-				$(e).hide()
-			}
-			else {
-				$(e).show()
-			}
-		})
-		// if any checkboxes are checked, then all "custom" action buttons are shown.
-		// This means any action button that is not linked to a workflow transition.
-		if(checked.length>0){
-			$("input[workflow_transition='no']").show()
-		} else {
-			$("input[workflow_transition='no']").hide()
-		}
+		loading_transitions = false;
 	}
 
+	/**
+	* Controls the behavior when a checkbox of row selection is clicked.
+	* Updates the status of the 'select all' checkbox accordingly and also
+	* re-renders the workflow action buttons from the bottom of the list
+	* based on the allowed transitions of the currently selected items
+	*/
 	function select_one_clicked() {
-		$("input[name='uids:list']").live("click", function () {
-			show_or_hide_transition_buttons();
-		})
+		"use strict";
+		$("input[type='checkbox'][id*='_cb_']").live("click", function () {
+			var blst = $(this).parents("table.bika-listing-table");
+			render_transition_buttons(blst);
+			// Modify all checkbox statuses
+			var checked = $("input[type='checkbox'][id*='_cb_']:checked");
+			var all =  $("input[type='checkbox'][id*='_cb_']");
+			var checkall = $(blst).find("input[id*='select_all']");
+			checkall.prop("checked", checked.length == all.length);
+		});
 	}
 
+	/**
+	* Controls the behavior when the 'select all' checkbox is clicked.
+	* Checks/Unchecks all the row selection checkboxes and once done,
+	* re-renders the workflow action buttons from the bottom of the list,
+	* based on the allowed transitions for the currently selected items
+	*/
 	function select_all_clicked() {
+		"use strict";
 		// select all (on this page at least)
 		$("input[id*='select_all']").live("click", function () {
-			var checkboxes = $(this).parents("form").find("[id*='_cb_']")
-			if ($(this).prop("checked")) {
-				$(checkboxes).filter("input:checkbox:not(:checked)").prop("checked", true)
-			}
-			else {
-				$(checkboxes).filter("input:checkbox:checked").prop("checked", false)
-			}
-			show_or_hide_transition_buttons();
-		})
+			var blst = $(this).parents("table.bika-listing-table");
+			var checkboxes = $(blst).find("[id*='_cb_']");
+			$(checkboxes).prop("checked", $(this).prop("checked"));
+			render_transition_buttons(blst);
+		});
 	}
 
-	function manage_select_all_state() {
-		// modify select_all checkbox when regular checkboxes are modified
-		$("input[id*='_cb_']").live("change", function () {
-			form_id = $(this).parents("form").attr("id")
-			all_selected = true
-			$.each($("input[id^='" + form_id + "_cb_']"), function (i, v) {
-				if (!($(v).prop("checked"))) {
-					all_selected = false
-				}
-			})
-			if (all_selected) {
-				$("#" + form_id + "_select_all").prop("checked", true)
+	/**
+	* Re-generates the workflow action buttons from the bottom of the list in
+	* accordance with the allowed transitions for the currently selected items.
+	* This is, makes the intersection within all allowed transitions and adds
+	* the corresponding buttons to the workflow action bar.
+	*/
+	function render_transition_buttons(blst) {
+		"use strict";
+		var allowed_transitions = [];
+		var checked = $(blst).find("input[type='checkbox'][id*='_cb_']:checked");
+		$(checked).each(function(e) {
+			var transitions = $(this).attr('data-valid_transitions');
+			transitions = transitions.split(',');
+			if (allowed_transitions.length > 0) {
+				transitions = transitions.filter(function(el) {
+					return allowed_transitions.indexOf(el) != -1;
+				});
 			}
-			else {
-				$("#" + form_id + "_select_all").prop("checked", false)
-			}
-		})
+			allowed_transitions = transitions;
+		});
+		// Generate the action buttons
+		var buttonspane = $(blst).find('span.workflow_action_buttons');
+		$(buttonspane).find('input[id*="_transition"]').remove();
+		for (var i = 0; i < allowed_transitions.length; i++) {
+			var trans = allowed_transitions[i];
+			var button = '<input id="'+trans+'_transition" class="context workflow_action_button action_button allowMultiSubmit" type="submit" url="" value="'+_(PMF(trans+'_transition_title'))+'" transition="'+trans+'" name="workflow_action_button">';
+			$(buttonspane).append(button);
+		}
 	}
 
 	function listing_string_input_keypress() {
+		"use strict";
 		$(".listing_string_entry,.listing_select_entry").live("keypress", function (event) {
 			// Prevent automatic submissions of manage_results forms when enter is pressed
 			var enter = 13

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -244,14 +244,14 @@ function BikaListingTableView() {
 		"use strict";
 		var allowed_transitions = [];
 		var hidden_transitions = $(blst).find('input[type="hidden"][id="hide_transitions"]');
-		hidden_transitions = $(hidden_transitions).val().split(',');
+		hidden_transitions = $(hidden_transitions).length == 1 ? $(hidden_transitions).val() : '';
+		hidden_transitions = hidden_transitions === '' ? [] : hidden_transitions.split(',');
 		var restricted_transitions = $(blst).find('input[type="hidden"][id="restricted_transitions"]');
-		restricted_transitions = $(restricted_transitions).val();
+		restricted_transitions = $(restricted_transitions).length == 1 ? $(restricted_transitions).val() : '';
 		restricted_transitions = restricted_transitions === '' ? [] : restricted_transitions.split(',');
 		var checked = $(blst).find("input[type='checkbox'][id*='_cb_']:checked");
 		$(checked).each(function(e) {
 			var transitions = $(this).attr('data-valid_transitions');
-			console.log(transitions);
 			transitions = transitions.split(',');
 			if (restricted_transitions.length > 0) {
 				// Do not want transitions other than those defined in bikalisting
@@ -259,19 +259,16 @@ function BikaListingTableView() {
 					return restricted_transitions.indexOf(el) != -1;
 				});
 			}
-			console.log(transitions);
 			// Do not show hidden transitions
 			transitions = transitions.filter(function(el) {
 				return hidden_transitions.indexOf(el) == -1;
 			});
-			console.log(transitions);
 			// We only want the intersection within all selected items
 			if (allowed_transitions.length > 0) {
 				transitions = transitions.filter(function(el) {
 					return allowed_transitions.indexOf(el) != -1;
 				});
 			}
-			console.log(transitions);
 			allowed_transitions = transitions;
 		});
 		if (restricted_transitions.length > 0) {

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -263,11 +263,22 @@ function BikaListingTableView() {
 		});
 		// Generate the action buttons
 		var buttonspane = $(blst).find('span.workflow_action_buttons');
-		$(buttonspane).find('input[id*="_transition"]').remove();
+		$(buttonspane).html('');
 		for (var i = 0; i < allowed_transitions.length; i++) {
 			var trans = allowed_transitions[i];
-			var button = '<input id="'+trans+'_transition" class="context workflow_action_button action_button allowMultiSubmit" type="submit" url="" value="'+_(PMF(trans+'_transition_title'))+'" transition="'+trans+'" name="workflow_action_button">';
+			var button = '<input id="'+trans+'_transition" class="context workflow_action_button action_button allowMultiSubmit" type="submit" url="" value="'+_(PMF(trans+'_transition_title'))+'" transition="'+trans+'" name="workflow_action_button">&nbsp;';
 			$(buttonspane).append(button);
+		}
+		// Add now custom actions
+		if ($(checked).length > 0) {
+			var custom_actions = $(blst).find('input[type="hidden"].custom_action');
+			$(custom_actions).each(function(e){
+				var trans = $(this).val();
+				var url = $(this).attr('url');
+				var title = $(this).attr('title');
+				var button = '<input id="'+trans+'_transition" class="context workflow_action_button action_button allowMultiSubmit" type="submit" url="'+url+'" value="'+title+'" transition="'+trans+'" name="workflow_action_button">&nbsp;';
+				$(buttonspane).append(button);
+			});
 		}
 	}
 

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -250,6 +250,9 @@ Colum Headers
 Workflow Actions
 ********************************</tal:comment>
         <td class="workflow_actions">
+            <input type="hidden" id="hide_transitions"
+                tal:condition="view/bika_listing/show_workflow_action_buttons"
+                tal:attributes="value python:','.join(view.bika_listing.review_state.get('hide_transitions',[]))"/>
             <span class="workflow_action_buttons"
                 tal:condition="view/bika_listing/show_workflow_action_buttons">
             </span>

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -253,6 +253,15 @@ Workflow Actions
             <input type="hidden" id="hide_transitions"
                 tal:condition="view/bika_listing/show_workflow_action_buttons"
                 tal:attributes="value python:','.join(view.bika_listing.review_state.get('hide_transitions',[]))"/>
+            <tal:custom_actions condition="view/bika_listing/show_workflow_action_buttons">
+                <tal:customaction repeat="caction python: view.bika_listing.review_state.get('custom_actions',[])">
+                    <input type="hidden" class="custom_action"
+                        tal:condition="python:caction.get('id', '')"
+                        tal:attributes="value caction/id;
+                                        title python:caction.get('title', caction.get('id'));
+                                        url python:caction.get('url','')"/>
+                </tal:customaction>
+            </tal:custom_actions>
             <span class="workflow_action_buttons"
                 tal:condition="view/bika_listing/show_workflow_action_buttons">
             </span>

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -251,25 +251,7 @@ Workflow Actions
 ********************************</tal:comment>
         <td class="workflow_actions">
             <span class="workflow_action_buttons"
-                tal:define="actions view/bika_listing/get_workflow_actions">
-                <span tal:omit-tag="python:True" tal:repeat="action actions"
-                    tal:condition="view/bika_listing/show_workflow_action_buttons">
-                    <input
-                        type="hidden"
-                        tal:attributes="name action/title;
-                                        value action/id;"/>
-                    <input
-                        class="context workflow_action_button action_button allowMultiSubmit"
-                        type="submit"
-                        name="workflow_action_button"
-                        i18n:attributes="value"
-                        i18n:domain="plone"
-                        tal:attributes="
-                            id python:action['id']+'_transition';
-                            transition action/id;
-                            value string:${action/id}_transition_title;
-                            url python:action.get('url', '');"/>
-                </span>
+                tal:condition="view/bika_listing/show_workflow_action_buttons">
             </span>
         </td>
         <td class="batching" style="text-align:right">

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -250,6 +250,9 @@ Colum Headers
 Workflow Actions
 ********************************</tal:comment>
         <td class="workflow_actions">
+            <input type="hidden" id="restricted_transitions"
+                tal:condition="view/bika_listing/show_workflow_action_buttons"
+                tal:attributes="value python:','.join([trans['id'] for trans in view.bika_listing.review_state.get('transitions', [])])"/>
             <input type="hidden" id="hide_transitions"
                 tal:condition="view/bika_listing/show_workflow_action_buttons"
                 tal:attributes="value python:','.join(view.bika_listing.review_state.get('hide_transitions',[]))"/>

--- a/bika/lims/browser/worksheet/templates/analyses_transposed.pt
+++ b/bika/lims/browser/worksheet/templates/analyses_transposed.pt
@@ -65,7 +65,7 @@
                     <tr class="noborder" tal:condition="python:len(rows) > 0">
                         <td class="workflow_actions">
                             <span class="workflow_action_buttons"
-                                tal:define="actions view/bika_listing/get_workflow_actions;
+                                tal:define="actions view/get_workflow_actions;
                                             exclude_actions python:['unassign',];
                                             actions python:[a for a in actions if a.get('id','') not in exclude_actions];">
                                 <span tal:omit-tag="python:True" tal:repeat="action actions"

--- a/bika/lims/jsonapi/allowedtransitionsfor.py
+++ b/bika/lims/jsonapi/allowedtransitionsfor.py
@@ -57,13 +57,13 @@ class allowedTransitionsFor(object):
         return ret
 
     def allowed_transitions_for_many(self, context, request):
-        """/@@API/doActionFor: Perform workflow transition on a list of objects.
+        """/@@API/allowedTransitionsFor_many: Returns a list of dictionaries. Each
+        dictionary has the following structure:
+            {'uid': <uid_object_passed_in>,
+             'transitions': [<transtion_id_1>, <transition_id2>]}
 
-        required parameters:
-
-            - obj_paths: a json encoded list of objects to transition.
-            - action: the id of the transition
-
+        Required parameters:
+            - uid: uids of the objects to get the allowed transitions from
         """
         uc = getToolByName(context, 'uid_catalog')
         uids = json.loads(request.get('uid', '[]'))

--- a/bika/lims/jsonapi/allowedtransitionsfor.py
+++ b/bika/lims/jsonapi/allowedtransitionsfor.py
@@ -1,0 +1,93 @@
+from AccessControl import ClassSecurityInfo
+from bika.lims.workflow import getAllowedTransitions
+from plone.jsonapi.core import router
+from plone.jsonapi.core.interfaces import IRouteProvider
+from Products.CMFCore.utils import getToolByName
+from zExceptions import BadRequest
+from zope import interface
+import json
+import plone
+
+
+class allowedTransitionsFor(object):
+    interface.implements(IRouteProvider)
+
+    def initialize(self, context, request):
+        self.context = context
+        self.request = request
+
+    @property
+    def routes(self):
+        return (
+            ("/allowedTransitionsFor", "allowedTransitionsFor",
+                self.allowed_transitions_for,
+                dict(methods=['GET', 'POST'])),
+            ("/allowedTransitionsFor_many", "allowedTransitionsFor_many",
+                self.allowed_transitions_for_many,
+                dict(methods=['GET', 'POST'])),
+        )
+
+    def allowed_transitions_for(self, context, request):
+        """/@@API/allowedTransitionsFor: Returns a list with the ids of the
+        transitions that can be applied to the object for the uid passed in
+
+        Required parameters:
+            - uid: the uid of the object to get the allowed transitions
+        """
+        plone.protect.CheckAuthenticator(self.request)
+        uc = getToolByName(context, 'uid_catalog')
+        uid = request.get('uid', '')
+        if not uid:
+            raise BadRequest("No object UID specified in request")
+        allowed_transitions = []
+        try:
+            obj = uc(UID=uid)[0].getObject()
+            allowed_transitions = getAllowedTransitions(obj)
+        except Exception as e:
+            msg = "Cannot get the allowed transitions for '{0}' ({1})".format(
+                uid, e.message)
+            raise BadRequest(msg)
+        ret = {
+            "url": router.url_for("allowedTransitionsFor",
+                                  force_external=True),
+            "success": True,
+            "error": False,
+            "transitions": allowed_transitions
+        }
+        return ret
+
+    def allowed_transitions_for_many(self, context, request):
+        """/@@API/doActionFor: Perform workflow transition on a list of objects.
+
+        required parameters:
+
+            - obj_paths: a json encoded list of objects to transition.
+            - action: the id of the transition
+
+        """
+        uc = getToolByName(context, 'uid_catalog')
+        uids = json.loads(request.get('uid', '[]'))
+        if not uids:
+            raise BadRequest("No object UID specified in request")
+
+        allowed_transitions = []
+        try:
+            objs = uc(UID=uids)
+            for obj in objs:
+                obj = obj.getObject()
+                transitions = getAllowedTransitions(obj)
+                allowed_transitions.append({'uid': obj.UID(),
+                                            'transitions': transitions})
+        except Exception as e:
+            msg = "Cannot get the allowed transitions for '{0}' ({1})".format(
+                uid, e.message)
+            raise BadRequest(msg)
+
+        ret = {
+            "url": router.url_for("allowedTransitionsFor_many",
+                                  force_external=True),
+            "success": True,
+            "error": False,
+            "transitions": allowed_transitions
+        }
+        return ret

--- a/bika/lims/jsonapi/configure.zcml
+++ b/bika/lims/jsonapi/configure.zcml
@@ -30,7 +30,7 @@
     name="bika.lims.jsonapi.remove"
     provides="plone.jsonapi.core.interfaces.IRouteProvider"
     factory=".remove.Remove" />
-    
+
   <utility
     name="bika.lims.jsonapi.getusers"
     provides="plone.jsonapi.core.interfaces.IRouteProvider"
@@ -45,5 +45,10 @@
     name="bika.lims.jsonapi.calculate_partitions"
     provides="plone.jsonapi.core.interfaces.IRouteProvider"
     factory=".calculate_partitions.calculate_partitions" />
+
+  <utility
+    name="bika.lims.jsonapi.allowedtransitionsfor"
+    provides="plone.jsonapi.core.interfaces.IRouteProvider"
+    factory=".allowedtransitionsfor.allowedTransitionsFor" />
 
 </configure>

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -251,6 +251,7 @@ def AfterTransitionEventHandler(instance, event):
     logger.info(msg)
     after_event()
 
+
 def get_workflow_actions(obj):
     """ Compile a list of possible workflow transitions for this object
     """
@@ -258,11 +259,8 @@ def get_workflow_actions(obj):
     def translate(id):
         return t(PMF(id + "_transition_title"))
 
-    workflow = getToolByName(obj, 'portal_workflow')
-    actions = [{"id": it["id"],
-                "title": translate(it["id"])}
-               for it in workflow.getTransitionsFor(obj)]
-
+    transids = getAllowedTransitions(obj)
+    actions = [{'id': it, 'title': translate(it)} for it in transids]
     return actions
 
 
@@ -302,6 +300,19 @@ def isTransitionAllowed(instance, transition_id, active_only=True):
             return True
 
     return False
+
+
+def getAllowedTransitions(instance):
+    """Returns a list with the transition ids that can be performed against
+    the instance passed in.
+    :param instance: A content object
+    :type instance: ATContentType
+    :returns: A list of transition/action ids
+    :rtype: list
+    """
+    wftool = getToolByName(instance, "portal_workflow")
+    transitions = wftool.getTransitionsFor(instance)
+    return [trans['id'] for trans in transitions]
 
 
 def wasTransitionPerformed(instance, transition_id):


### PR DESCRIPTION
The transition buttons from the bottom of the lists are generated dynamically. To prevent user confusion, only buttons for transitions that are shared with all selected items are rendered.