### PR TITLE
Bika Listing: States not displayed

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -956,7 +956,7 @@ class BikaListingView(BrowserView):
                     except:
                         logger.warning("Cannot obtain title for state {0} and "
                                        "object {1}".format(state, obj.getId))
-                if st_title and state_var == obj.review_state:
+                if st_title and state == obj.review_state:
                     results_dict['state_title'] = st_title
 
             # extra classes for individual fields on this item

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -167,7 +167,7 @@ function BikaListingTableView() {
 		var checkall = $("input[id*='select_all']");
 		$(checkall).hide();
 		var wo_trans = $("input[type='checkbox'][id*='_cb_'][data-valid_transitions='']");
-		$(wo_trans).hide();
+		$(wo_trans).prop('enabled', false);
 		$(wo_trans).each(function(e){
 			uids.push($(this).val());
 		});
@@ -188,7 +188,7 @@ function BikaListingTableView() {
 							var trans = data.transitions[i].transitions;
 							var el = $("input[type='checkbox'][id*='_cb_'][value='"+uid+"']");
 							el.attr('data-valid_transitions', trans.join(','));
-							$(el).show();
+							$(el).prop('enabled', true);
 						}
 						$("input[id*='select_all']").fadeIn();
 					}


### PR DESCRIPTION
- Fixing: states titles aren't shown in bika listing
- Do not hide the checkboxes, but disable them.