### PR TITLE
NDEV-9 Report performance

### DIFF
--- a/bika/lims/browser/reports/__init__.py
+++ b/bika/lims/browser/reports/__init__.py
@@ -51,6 +51,7 @@ class ProductivityView(BrowserView):
             report_dict = adapter(self.context, self.request)
             report_dict['id'] = name
             self.additional_reports.append(report_dict)
+        self.template()
 
         return self.template()
 
@@ -212,6 +213,7 @@ class ReportHistoryView(BikaListingView):
             items[x]['replace']['Title'] = \
                 "<a href='%s/at_download/ReportFile'>%s</a>" % \
                 (obj_url, items[x]['Title'])
+
         return items
 
 

--- a/bika/lims/browser/reports/__init__.py
+++ b/bika/lims/browser/reports/__init__.py
@@ -51,7 +51,6 @@ class ProductivityView(BrowserView):
             report_dict = adapter(self.context, self.request)
             report_dict['id'] = name
             self.additional_reports.append(report_dict)
-        self.template()
 
         return self.template()
 

--- a/bika/lims/browser/reports/__init__.py
+++ b/bika/lims/browser/reports/__init__.py
@@ -212,7 +212,6 @@ class ReportHistoryView(BikaListingView):
             items[x]['replace']['Title'] = \
                 "<a href='%s/at_download/ReportFile'>%s</a>" % \
                 (obj_url, items[x]['Title'])
-
         return items
 
 

--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -10,6 +10,167 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims.utils import getUsers
 from bika.lims import bikaMessageFactory as _
 from bika.lims import PMF
+from plone.memoize import ram
+from time import time
+
+
+def update_timer():
+    """
+    This function sets the time between updates of cached values
+    """
+    return time() // (24 *60 * 60)
+
+def _cache_key_select_state(method, self, workflow_id, field_id, field_title):
+    """
+    This function returns the key used to decide if select_state has to be recomputed
+    """
+    key = update_timer(), workflow_id, field_id, field_title
+    return key
+
+
+def _cache_key_select_analysiscategory(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_analysiscategory has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_analysisservice(method, self, allow_blank,
+                                      multiselect, style=None):
+    """
+    This function returns the key used to decide if method select_analysisservice has to be recomputed
+    """
+    key = update_timer(), allow_blank, multiselect, style
+    return key
+
+
+def _cache_key_select_analysisspecification(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_analysisspecification has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_analyst(method, self, allow_blank=False, style=None):
+    """
+    This function returns the key used to decide if method select_analyst has to be recomputed
+    """
+    key = update_timer(),allow_blank, style
+    return key
+
+
+def _cache_key_select_user(method, self, allow_blank=True, style=None):
+    """
+    This function returns the key used to decide if method select_user has to be recomputed
+    """
+    key = update_timer(), allow_blank, style
+    return key
+
+
+def _cache_key_select_client(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_client has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_contact(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_contact has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_daterange(method, self, field_id, field_title, style=None):
+    """
+    This function returns the key used to decide if method select_daterange has to be recomputed
+    """
+    key = update_timer(), field_id, field_title, style
+    return key
+
+
+def _cache_key_select_instrument(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_instrument has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_period(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_period has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_profile(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_profile has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_supplier(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_supplier has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+def _cache_key_select_reference_sample(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_reference_sample has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_reference_service(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_reference_service has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
+
+def _cache_key_select_samplepoint(method, self, allow_blank=True, multiselect=False, style=None):
+    """
+    This function returns the key used to decide if method select_samplepoint has to be recomputed
+    """
+    key = update_timer(), allow_blank, multiselect, style
+    return key
+
+
+def _cache_key_select_sample_type(method, self, allow_blank=True, multiselect=False, style=None):
+    """
+    This function returns the key used to decide if method select_sample_type has to be recomputed
+    """
+    key = update_timer(), allow_blank, multiselect, style
+    return key
+
+
+def _cache_key_select_groupingperiod(method, self, allow_blank=True, multiselect=False, style=None):
+    """
+    This function returns the key used to decide if method select_groupingperiod has to be recomputed
+    """
+    key = update_timer(), allow_blank, multiselect, style
+    return key
+
+
+def _cache_key_select_output_format(method, self, style=None):
+    """
+    This function returns the key used to decide if method select_output_format has to be recomputed
+    """
+    key = update_timer(), style
+    return key
+
 
 class SelectionMacrosView(BrowserView):
     """ Display snippets for the query form, and
@@ -29,7 +190,6 @@ class SelectionMacrosView(BrowserView):
                                  }
 
     """
-
     def __init__(self, context, request):
         super(SelectionMacrosView, self).__init__(context, request)
         self.bc = self.bika_catalog
@@ -37,18 +197,22 @@ class SelectionMacrosView(BrowserView):
         self.bsc = self.bika_setup_catalog
         self.pc = self.portal_catalog
         self.rc = self.reference_catalog
+        self.analysiscategories = None
 
     select_analysiscategory_pt = ViewPageTemplateFile(
         "select_analysiscategory.pt")
 
+    @ram.cache(_cache_key_select_analysiscategory)
     def select_analysiscategory(self, style=None):
         self.style = style
-        self.analysiscategories = self.bsc(portal_type='AnalysisCategory',
-                                           sort_on='sortable_title')
+        if self.analysiscategories is None:
+            self.analysiscategories = self.bsc(portal_type='AnalysisCategory',
+                                               sort_on='sortable_title')
         return self.select_analysiscategory_pt()
 
     select_analysisservice_pt = ViewPageTemplateFile("select_analysisservice.pt")
 
+    @ram.cache(_cache_key_select_analysisservice)
     def select_analysisservice(self, allow_blank=True, multiselect=False,
                                style=None):
         self.style = style
@@ -75,25 +239,20 @@ class SelectionMacrosView(BrowserView):
     select_analysisspecification_pt = ViewPageTemplateFile(
         "select_analysisspecification.pt")
 
+    @ram.cache(_cache_key_select_analysisspecification)
     def select_analysisspecification(self, style=None):
         self.style = style
-        specfolder_uid = self.context.bika_setup.bika_analysisspecs.UID()
         res = []
         bsc = getToolByName(self.context, "bika_setup_catalog")
         for s in bsc(portal_type='AnalysisSpec'):
-            if s.getClientUID == specfolder_uid:
-                res.append({'uid': s.UID, 'title': s.Title})
-        for c in self.context.clients.objectValues():
-            for s in c.objectValues():
-                if s.portal_type != 'AnalysisSpec':
-                    continue
-                res.append(
-                    {'uid': s.UID(), 'title': s.Title() + " (" + c.Title() + ")"})
+            res.append({'uid': s.UID, 'title': s.Title})
+
         self.specs = res
         return self.select_analysisspecification_pt()
 
     select_analyst_pt = ViewPageTemplateFile("select_analyst.pt")
 
+    @ram.cache(_cache_key_select_analyst)
     def select_analyst(self, allow_blank=False, style=None):
         self.style = style
         self.analysts = getUsers(self.context,
@@ -103,6 +262,7 @@ class SelectionMacrosView(BrowserView):
 
     select_user_pt = ViewPageTemplateFile("select_user.pt")
 
+    @ram.cache(_cache_key_select_user)
     def select_user(self, allow_blank=True, style=None):
         self.style = style
         self.allow_blank = allow_blank
@@ -111,6 +271,7 @@ class SelectionMacrosView(BrowserView):
 
     select_client_pt = ViewPageTemplateFile("select_client.pt")
 
+    @ram.cache(_cache_key_select_client)
     def select_client(self, style=None):
         self.style = style
         self.clients = self.pc(portal_type='Client', inactive_state='active',
@@ -130,6 +291,7 @@ class SelectionMacrosView(BrowserView):
 
     select_contact_pt = ViewPageTemplateFile("select_contact.pt")
 
+    @ram.cache(_cache_key_select_contact)
     def select_contact(self, style=None):
         self.style = style
         self.contacts = self.pc(portal_type='Contact', inactive_state='active',
@@ -138,11 +300,35 @@ class SelectionMacrosView(BrowserView):
 
     select_daterange_pt = ViewPageTemplateFile("select_daterange.pt")
 
-    def select_daterange(self, field_id, field_title, style=None):
+    def _select_daterange(self, field_id, field_title, style=None):
         self.style = style
         self.field_id = field_id
         self.field_title = _(field_title)
         return self.select_daterange_pt()
+
+    @ram.cache(_cache_key_select_daterange)
+    def select_daterange(self, field_id, field_title, style=None):
+        return self._select_daterange(field_id, field_title, style)
+
+    @ram.cache(_cache_key_select_daterange)
+    def select_daterange_requested(self, field_id, field_title, style=None):
+        return self._select_daterange(field_id, field_title, style)
+
+    @ram.cache(_cache_key_select_daterange)
+    def select_daterange_created(self, field_id, field_title, style=None):
+        return self._select_daterange(field_id, field_title, style)
+
+    @ram.cache(_cache_key_select_daterange)
+    def select_daterange_received(self, field_id, field_title, style=None):
+        return self._select_daterange(field_id, field_title, style)
+
+    @ram.cache(_cache_key_select_daterange)
+    def select_daterange_published(self, field_id, field_title, style=None):
+        return self._select_daterange(field_id, field_title, style)
+
+    @ram.cache(_cache_key_select_daterange)
+    def select_daterange_loaded(self, field_id, field_title, style=None):
+        return self._select_daterange(field_id, field_title, style)
 
     def parse_daterange(self, request, field_id, field_title):
         from_date = request.get('%s_fromdate' % field_id, None)
@@ -175,6 +361,7 @@ class SelectionMacrosView(BrowserView):
 
     select_instrument_pt = ViewPageTemplateFile("select_instrument.pt")
 
+    @ram.cache(_cache_key_select_instrument)
     def select_instrument(self, style=None):
         self.style = style
         self.instruments = self.bsc(portal_type='Instrument',
@@ -184,12 +371,14 @@ class SelectionMacrosView(BrowserView):
 
     select_period_pt = ViewPageTemplateFile("select_period.pt")
 
+    @ram.cache(_cache_key_select_period)
     def select_period(self, style=None):
         self.style = style
         return self.select_period_pt()
 
     select_profile_pt = ViewPageTemplateFile("select_profile.pt")
 
+    @ram.cache(_cache_key_select_profile)
     def select_profile(self, style=None):
         self.style = style
         self.analysisprofiles = self.bsc(portal_type='AnalysisProfile',
@@ -199,6 +388,7 @@ class SelectionMacrosView(BrowserView):
 
     select_supplier_pt = ViewPageTemplateFile("select_supplier.pt")
 
+    @ram.cache(_cache_key_select_supplier)
     def select_supplier(self, style=None):
         self.style = style
         self.suppliers = self.bsc(portal_type='Supplier', inactive_state='active',
@@ -208,6 +398,7 @@ class SelectionMacrosView(BrowserView):
     select_reference_sample_pt = ViewPageTemplateFile(
         "select_reference_sample.pt")
 
+    @ram.cache(_cache_key_select_reference_sample)
     def select_reference_sample(self, style=None):
         self.style = style
         return self.select_reference_sample_pt()
@@ -215,13 +406,14 @@ class SelectionMacrosView(BrowserView):
     select_reference_service_pt = ViewPageTemplateFile(
         "select_reference_service.pt")
 
+    @ram.cache(_cache_key_select_reference_service)
     def select_reference_service(self, style=None):
         self.style = style
         return self.select_reference_service_pt()
 
     select_state_pt = ViewPageTemplateFile("select_state.pt")
 
-    def select_state(self, workflow_id, field_id, field_title, style=None):
+    def _select_state(self, workflow_id, field_id, field_title, style=None):
         self.style = style
         self.field_id = field_id
         self.field_title = field_title
@@ -231,6 +423,22 @@ class SelectionMacrosView(BrowserView):
             state = states[state_id]
             self.states.append({'id': state.getId(), 'title': state.title})
         return self.select_state_pt()
+
+    @ram.cache(_cache_key_select_state)
+    def select_state(self, workflow_id, field_id, field_title, style=None):
+        return self._select_state(workflow_id, field_title, field_title, style)
+
+    @ram.cache(_cache_key_select_state)
+    def select_state_analysis(self, workflow_id, field_id, field_title, style=None):
+        return self._select_state(workflow_id, field_title, field_title, style)
+
+    @ram.cache(_cache_key_select_state)
+    def select_state_cancellation(self, workflow_id, field_id, field_title, style=None):
+        return self._select_state(workflow_id, field_title, field_title, style)
+
+    @ram.cache(_cache_key_select_state)
+    def select_state_worksheetanalysis(self, workflow_id, field_id, field_title, style=None):
+        return self._select_state(workflow_id, field_title, field_title, style)
 
     def parse_state(self, request, workflow_id, field_id, field_title):
         val = request.form.get(field_id, "")
@@ -245,6 +453,7 @@ class SelectionMacrosView(BrowserView):
 
     select_samplepoint_pt = ViewPageTemplateFile("select_samplepoint.pt")
 
+    @ram.cache(_cache_key_select_samplepoint)
     def select_samplepoint(self, allow_blank=True, multiselect=False, style=None):
         self.style = style
         self.allow_blank = allow_blank
@@ -267,6 +476,7 @@ class SelectionMacrosView(BrowserView):
 
     select_sampletype_pt = ViewPageTemplateFile("select_sampletype.pt")
 
+    @ram.cache(_cache_key_select_sample_type)
     def select_sampletype(self, allow_blank=True, multiselect=False, style=None):
         self.style = style
         self.allow_blank = allow_blank
@@ -289,6 +499,7 @@ class SelectionMacrosView(BrowserView):
 
     select_groupingperiod_pt = ViewPageTemplateFile("select_groupingperiod.pt")
 
+    @ram.cache(_cache_key_select_groupingperiod)
     def select_groupingperiod(self, allow_blank=True, multiselect=False,
                               style=None):
         self.style = style
@@ -297,6 +508,7 @@ class SelectionMacrosView(BrowserView):
 
     select_output_format_pt = ViewPageTemplateFile("select_output_format.pt")
 
+    @ram.cache(_cache_key_select_output_format)
     def select_output_format(self, style=None):
         self.style = style
         return self.select_output_format_pt()

--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -197,7 +197,6 @@ class SelectionMacrosView(BrowserView):
         self.bsc = self.bika_setup_catalog
         self.pc = self.portal_catalog
         self.rc = self.reference_catalog
-        self.analysiscategories = None
 
     select_analysiscategory_pt = ViewPageTemplateFile(
         "select_analysiscategory.pt")
@@ -205,8 +204,7 @@ class SelectionMacrosView(BrowserView):
     @ram.cache(_cache_key_select_analysiscategory)
     def select_analysiscategory(self, style=None):
         self.style = style
-        if self.analysiscategories is None:
-            self.analysiscategories = self.bsc(portal_type='AnalysisCategory',
+        self.analysiscategories = self.bsc(portal_type='AnalysisCategory',
                                                sort_on='sortable_title')
         return self.select_analysiscategory_pt()
 

--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -246,7 +246,6 @@ class SelectionMacrosView(BrowserView):
         bsc = getToolByName(self.context, "bika_setup_catalog")
         for s in bsc(portal_type='AnalysisSpec'):
             res.append({'uid': s.UID, 'title': s.Title})
-
         self.specs = res
         return self.select_analysisspecification_pt()
 

--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -20,6 +20,7 @@ def update_timer():
     """
     return time() // (24 *60 * 60)
 
+
 def _cache_key_select_state(method, self, workflow_id, field_id, field_title):
     """
     This function returns the key used to decide if select_state has to be recomputed
@@ -190,6 +191,7 @@ class SelectionMacrosView(BrowserView):
                                  }
 
     """
+
     def __init__(self, context, request):
         super(SelectionMacrosView, self).__init__(context, request)
         self.bc = self.bika_catalog
@@ -205,7 +207,7 @@ class SelectionMacrosView(BrowserView):
     def select_analysiscategory(self, style=None):
         self.style = style
         self.analysiscategories = self.bsc(portal_type='AnalysisCategory',
-                                               sort_on='sortable_title')
+                                           sort_on='sortable_title')
         return self.select_analysiscategory_pt()
 
     select_analysisservice_pt = ViewPageTemplateFile("select_analysisservice.pt")

--- a/bika/lims/browser/reports/templates/productivity.pt
+++ b/bika/lims/browser/reports/templates/productivity.pt
@@ -109,7 +109,7 @@
                 <input type="hidden" name="report_id"
                        value="productivity_dailysamplesreceived"/>
                 <fieldset>
-                    <tal:x content="structure python:view.selection_macros.select_daterange(
+                    <tal:x content="structure python:view.selection_macros.select_daterange_received(
                                                               field_id='getDateReceived',
                                                               field_title='Date Received')"/>
                     <tal:x content="structure context/@@selection_macros/select_output_format"/>
@@ -141,7 +141,7 @@
                 <input type="hidden" name="report_id"
                        value="productivity_samplereceivedvsreported"/>
                 <fieldset>
-                    <tal:x content="structure python:view.selection_macros.select_daterange(
+                    <tal:x content="structure python:view.selection_macros.select_daterange_received(
                                                               field_id='getDateReceived',
                                                               field_title='Date Received')"/>
                     <tal:x content="structure context/@@selection_macros/select_output_format"/>
@@ -176,21 +176,21 @@
                    value="productivity_analysesperservice"/>
             <fieldset>
                 <tal:x content="structure context/@@selection_macros/select_client"/>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_requested(
                                                                field_id='Requested',
                                                                field_title='Date Requested')"/>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_published(
                                                                field_id='Published',
                                                                field_title='Date Published')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_analysis(
                                                                workflow_id='bika_analysis_workflow',
                                                                field_id='bika_analysis_workflow',
                                                                field_title='Analysis state')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_cancellation(
                                                                workflow_id='bika_cancellation_workflow',
                                                                field_id='bika_cancellation_workflow',
                                                                field_title='Cancellation state')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_worksheetanalysis(
                                                                workflow_id='bika_worksheetanalysis_workflow',
                                                                field_id='bika_worksheetanalysis_workflow',
                                                                field_title='Worksheet state')"/>
@@ -222,18 +222,18 @@
                    value="productivity_analysespersampletype"/>
             <fieldset>
                 <tal:x content="structure context/@@selection_macros/select_client"/>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_requested(
                                                                field_id='Requested',
                                                                field_title='Date Requested')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_analysis(
                                                                workflow_id='bika_analysis_workflow',
                                                                field_id='bika_analysis_workflow',
                                                                field_title='Analysis state')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_cancellation(
                                                                workflow_id='bika_cancellation_workflow',
                                                                field_id='bika_cancellation_workflow',
                                                                field_title='Cancellation state')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_worksheetanalysis(
                                                                workflow_id='bika_worksheetanalysis_workflow',
                                                                field_id='bika_worksheetanalysis_workflow',
                                                                field_title='Worksheet state')"/>
@@ -275,18 +275,18 @@
                    value="productivity_analysesperclient"/>
             <fieldset>
                 <tal:x content="structure context/@@selection_macros/select_client"/>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_requested(
                                                                field_id='Requested',
                                                                field_title='Date Requested')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_analysis(
                                                                workflow_id='bika_analysis_workflow',
                                                                field_id='bika_analysis_workflow',
                                                                field_title='Analysis state')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_cancellation(
                                                                workflow_id='bika_cancellation_workflow',
                                                                field_id='bika_cancellation_workflow',
                                                                field_title='Cancellation state')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_worksheetanalysis(
                                                                workflow_id='bika_worksheetanalysis_workflow',
                                                                field_id='bika_worksheetanalysis_workflow',
                                                                field_title='Worksheet state')"/>
@@ -318,10 +318,10 @@
                    value="productivity_analysestats"/>
             <fieldset>
                 <tal:x content="structure context/@@selection_macros/select_client"/>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_received(
                                                                field_id='Received',
                                                                field_title='Date Received')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_worksheetanalysis(
                                                                workflow_id='bika_worksheetanalysis_workflow',
                                                                field_id='bika_worksheetanalysis_workflow',
                                                                field_title='Worksheet state')"/>
@@ -358,7 +358,7 @@
                 <tal:x content="structure context/@@selection_macros/select_analyst"/>
                 <tal:x content="structure context/@@selection_macros/select_instrument"/>
                 <tal:x content="structure context/@@selection_macros/select_period"/>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_received(
                                                                field_id='Received',
                                                                field_title='Date Received')"/>
                 <tal:x content="structure context/@@selection_macros/select_output_format"/>
@@ -389,10 +389,10 @@
             <input type="hidden" name="report_id"
                    value="productivity_analysesperdepartment"/>
             <fieldset>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_requested(
                                                                field_id='getDateRequested',
                                                                field_title='Date Requested')"/>
-                <tal:x content="structure python:view.selection_macros.select_state(
+                <tal:x content="structure python:view.selection_macros.select_state_analysis(
                                                                workflow_id='bika_analysis_workflow',
                                                                field_id='getAnalysisState',
                                                                field_title='Analysis state')"/>
@@ -427,7 +427,7 @@
             <input type="hidden" name="report_id"
                    value="productivity_analysesperformedpertotal"/>
             <fieldset>
-                <tal:x content="structure python:view.selection_macros.select_daterange(
+                <tal:x content="structure python:view.selection_macros.select_daterange_requested(
                                                                field_id='getDateRequested',
                                                                field_title='Date Requested')"/>
                 <tal:x content="structure python:view.selection_macros.select_groupingperiod(
@@ -463,7 +463,7 @@
                        value="productivity_analysesattachments"/>
                 <fieldset>
                     <tal:x content="structure context/@@selection_macros/select_client"/>
-                    <tal:x content="structure python:view.selection_macros.select_daterange(
+                    <tal:x content="structure python:view.selection_macros.select_daterange_loaded(
                                                               field_id='Loaded',
                                                               field_title='Date Loaded')"/>
                     <tal:x content="structure context/@@selection_macros/select_output_format"/>
@@ -493,7 +493,7 @@
                 <input type="hidden" name="report_id"
                        value="productivity_dataentrydaybook"/>
                 <fieldset>
-                    <tal:x content="structure python:view.selection_macros.select_daterange(
+                    <tal:x content="structure python:view.selection_macros.select_daterange_created(
                                                               field_id='getDateCreated',
                                                               field_title='Date Created')"/>
                     <tal:x content="structure context/@@selection_macros/select_output_format"/>

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -622,3 +622,22 @@ def user_email(obj, userid):
     c = portal_catalog(portal_type='Contact', getUsername=userid)
     contact_email = c[0].getObject().getEmailAddress() if c else None
     return contact_email or member_email or ''
+
+
+def measure_time(func_to_measure):
+    """
+    This decorator allows to measure the execution time
+    of a function and prints it to the console.
+    :param func_to_measure: function to be decorated
+    """
+    def wrap(*args, **kwargs):
+        start_time = time()
+        return_value = func_to_measure(*args, **kwargs)
+        finish_time = time()
+        log = "%s took %0.4f seconds. start_time = %0.4f - finish_time = %0.4f\n" % (func_to_measure.func_name,
+                                                                                     finish_time-start_time,
+                                                                                     start_time,
+                                                                                     finish_time)
+        print log
+        return return_value
+    return wrap


### PR DESCRIPTION
- Removed full client object recovery from select_analysisspecification (one of the main culprits of such a long loading time).
- Cache storage of the widgets shown in reports' views to increase performance.
- Added a new utility to measure the execution time of a function.
 