### PR TITLE
NMRL-342 attribute error get department uid

### DIFF
--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2842,7 +2842,15 @@ class AnalysisRequest(BaseFolder):
         from this Analysis Request
         """
         bsc = getToolByName(self, 'bika_setup_catalog')
-        dept_uids = [b.getDepartmentUID for b in self.getAnalyses()]
+        dept_uids = []
+        for an in self.getAnalyses():
+            deptuid = None
+            if hasattr(an, 'getDepartmentUID'):
+                deptuid = an.getDepartmentUID
+            if not deptuid and hasattr(an, 'getObject'):
+                deptuid = an.getObject().getDepartmentUID()
+            if deptuid:
+                dept_uids.append(deptuid)
         brains = bsc(portal_type='Department', UID=dept_uids)
         depts = [b.getObject() for b in brains]
         return list(set(depts))


### PR DESCRIPTION
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1034, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 54, in wrap_func_args
  Module bika.lims.upgrade.v3_2_0_1704, line 38, in upgrade
  Module bika.lims.catalog.catalog_utilities, line 120, in setup_catalogs
  Module bika.lims.catalog.catalog_utilities, line 413, in _cleanAndRebuildIfNeeded
  Module plone.app.discussion.patches, line 47, in patchedClearFindAndRebuild
  Module OFS.FindSupport, line 239, in ZopeFindAndApply
  Module OFS.FindSupport, line 239, in ZopeFindAndApply
  Module OFS.FindSupport, line 227, in ZopeFindAndApply
  Module plone.app.discussion.patches, line 26, in indexObject
  Module Products.Archetypes.CatalogMultiplex, line 39, in indexObject
  Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 476, in catalog_object
  Module Products.ZCatalog.Catalog, line 340, in catalogObject
  Module Products.ZCatalog.Catalog, line 284, in updateMetadata
  Module Products.ZCatalog.Catalog, line 410, in recordify
  Module bika.lims.content.analysisrequest, line 2854, in getDepartmentUIDs
  Module bika.lims.content.analysisrequest, line 2845, in getDepartments
AttributeError: getDepartmentUID
```