### PR TITLE
NMRL-337-Error while rejecting AR

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_mail.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_mail.pt
@@ -4,7 +4,7 @@
         portal portal_url/getPortalObject;
         ar python:view.context;
         rej_widg    python:ar.getRejectionReasons();
-        reasons     python:ar.getRejectionReasons()[0].get('selected',[]) if rej_widg else []
+        reasons     python:ar.getRejectionReasons()[0].get('selected',[]) if rej_widg else [];
         lab python:ar.bika_setup.laboratory;">
 
     <tal:multiplereasons condition="python:len(reasons)&gt;1">

--- a/bika/lims/browser/js/bika.lims.rejection.js
+++ b/bika/lims/browser/js/bika.lims.rejection.js
@@ -107,6 +107,9 @@
                  other_val = $('.rejectionwidget-input-other').val();
              }
              else{other_ch_val=0;}
+         }else{
+            // Just set ch_val '0' if it is false.
+            ch_val=0;
          }
          // Gathering all values
          var rej_widget_state = {


### PR DESCRIPTION
Rejecting ARs was failing in some cases because of 'false' - '0' conversion. 