### PR TITLE
Temporary fix for sampling workflow. Automatic transition to sample_due

### DIFF
--- a/bika/lims/workflow/sample/events.py
+++ b/bika/lims/workflow/sample/events.py
@@ -97,6 +97,22 @@ def after_sample(obj):
     """
     _cascade_transition(obj, 'sample')
 
+    if obj.getSamplingWorkflowEnabled():
+        to_be_preserved = []
+        sample_due = []
+        lowest_state = 'sample_due'
+        for p in obj.objectValues('SamplePartition'):
+            if p.getPreservation():
+                lowest_state = 'to_be_preserved'
+                to_be_preserved.append(p)
+            else:
+                sample_due.append(p)
+        for p in to_be_preserved:
+            doActionFor(p, 'to_be_preserved')
+        for p in sample_due:
+            doActionFor(p, 'sample_due')
+        doActionFor(obj, lowest_state)
+
 
 def after_sample_due(obj):
     """Method triggered after a 'sample_due' transition for the Sample passed


### PR DESCRIPTION
Sampling workflow (sample_registered --> to_be_sampled --> sampled --> sample_due) was not working properly. The last transition (from sampled to sample_due) was not taking place automatically, and there was no possibility to transition sample, partitions, AR and analyses.

With this PR, an automatic transition to "sample_due" has been added in the Sample's "sample" after transition event, but only if the sampling worklow is enabled.

Note this is a temporary fix. The branch  workflow-sampling will eventually resolve this, as well as other workflow inconsistences.