### PR TITLE
NMRL-362 Error on Data Import

### DIFF
--- a/bika/lims/exportimport/dataimport.py
+++ b/bika/lims/exportimport/dataimport.py
@@ -82,7 +82,12 @@ class ImportView(BrowserView):
                 return lsd()
             else:
                 exim = instruments.getExim(self.request['exim'])
-                return exim.Import(self.context, self.request)
+                if not exim:
+                    er_mes = "Importer not found for: %s" % exim
+                    results = {'errors': er_mes, 'log': '', 'warns': ''}
+                    return json.dumps(results)
+                else:
+                    return exim.Import(self.context, self.request)
         else:
             return self.template()
 

--- a/bika/lims/exportimport/dataimport.py
+++ b/bika/lims/exportimport/dataimport.py
@@ -83,8 +83,8 @@ class ImportView(BrowserView):
             else:
                 exim = instruments.getExim(self.request['exim'])
                 if not exim:
-                    er_mes = "Importer not found for: %s" % exim
-                    results = {'errors': er_mes, 'log': '', 'warns': ''}
+                    er_mes = "Importer not found for: %s" % self.request['exim']
+                    results = {'errors': [er_mes], 'log': '', 'warns': ''}
                     return json.dumps(results)
                 else:
                     return exim.Import(self.context, self.request)

--- a/bika/lims/exportimport/load_setup_data.py
+++ b/bika/lims/exportimport/load_setup_data.py
@@ -91,7 +91,11 @@ class LoadSetupData(BrowserView):
                 workbook = load_workbook(filename=tmp)  # , use_iterators=True)
                 self.dataset_name = 'uploaded'
 
-        assert(workbook is not None)
+        if not workbook:
+            message = PMF("File not found...")
+            self.context.plone_utils.addPortalMessage(message)
+            self.request.RESPONSE.redirect(portal.absolute_url() + "/import")
+            return
 
         adapters = [[name, adapter]
                     for name, adapter


### PR DESCRIPTION
When import interface module is not found, system must return an error message.
Also found out that when submitting setup data form without an uploaded file, system failed. Added a portal message for that case as well.