### PR TITLE
NMRL-338 Replaced log the case in WARNING level instead of ERROR.

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -433,7 +433,7 @@ class ajaxAnalysisRequestSubmit():
                         "Bad time formatting: Getting '{}' but expecting an"\
                         " string with '%Y-%m-%d %H:%M' format."\
                         .format(samplingdate)
-                    logger.error(msg)
+                    logger.warning(msg)
                     ajax_form_error(self.errors, arnum=arnum, message=msg)
                     continue
                 now = datetime.datetime.now()

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -426,7 +426,7 @@ class ajaxAnalysisRequestSubmit():
                 samplingdate = state.get('SamplingDate', '')
                 try:
                     samp_date = datetime.datetime.strptime(
-                        samplingdate, "%Y-%m-%d %H:%M")
+                        samplingdate.strip(), "%Y-%m-%d %H:%M")
                 except ValueError:
                     print traceback.format_exc()
                     msg =\

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -433,7 +433,6 @@ class ajaxAnalysisRequestSubmit():
                         "Bad time formatting: Getting '{}' but expecting an"\
                         " string with '%Y-%m-%d %H:%M' format."\
                         .format(samplingdate)
-                    logger.warning(msg)
                     ajax_form_error(self.errors, arnum=arnum, message=msg)
                     continue
                 now = datetime.datetime.now()


### PR DESCRIPTION
When creating AR, in case of invalid DateTime format, system was logging it as an error. Since user will see an error message in GUI, we could log it as a _warning_.