### PR TITLE
NDEV-23 Attribute Error getBatch

### DIFF
--- a/bika/lims/barcode.py
+++ b/bika/lims/barcode.py
@@ -101,6 +101,6 @@ class barcode_entry(BrowserView):
         """
         ars = instance.getAnalysisRequests()
         if len(ars) == 1:
-            return self.handle_AnalysisRequest(instance)
+            return self.handle_AnalysisRequest(ars[0])
         else:
             return instance.absolute_url()


### PR DESCRIPTION
When a Batch has single AR, user must be redirected to AR view which is called by handle_AnalysisRequest. And that function expects an AR as parameter not a Batch. Just corrected that small mistake.