### PR TITLE
NDEV-20 Value Error in query url

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -320,8 +320,8 @@ function AnalysisRequestAddByCol() {
             options.url = options.url + "&search_query=" + $(element).attr("search_query")
         }
         else {
-            options.url = options.url + "&base_query=" + $(element).attr("base_query")
-            options.url = options.url + "&search_query=" + $.toJSON(query)
+            options.url = options.url + "&base_query=" + encodeURIComponent($(element).attr("base_query"))
+            options.url = options.url + "&search_query=" + encodeURIComponent($.toJSON(query))
         }
         options.url = options.url + "&colModel=" + $.toJSON($.parseJSON($(element).attr("combogrid_options")).colModel)
         options.url = options.url + "&search_fields=" + $.toJSON($.parseJSON($(element).attr("combogrid_options"))['search_fields'])


### PR DESCRIPTION
When generating URL for Sample Point Widget to filter, we add Sample Type Title to the URL. And if Title contains special characters (such as '&' , '='), it could fail. To avoid that, added URI encoder for URL builder. 