### PR TITLE
NDEV-39 Decimals rounding is not working as expected when uncertainties are set

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -950,10 +950,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         Further information at AbstractBaseAnalysis.getPrecision()
         """
-        schu = self.getField('Uncertainty').get(self)
-        if all([schu,
-                self.getAllowManualUncertainty(),
-                self.getPrecisionFromUncertainty()]):
+        allow_manual = self.getAllowedManualUncertainty()
+        precision_unc = self.getPrecisionFromUncertainty()
+        if allow_manual or precision_unc:
             uncertainty = self.getUncertainty(result)
             if uncertainty == 0:
                 return 1

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -938,19 +938,19 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def getPrecision(self, result=None):
         """Returns the precision for the Analysis.
 
-        - ManualUncertainty not set: returns the precision from the
-            AnalysisService.
+        - If ManualUncertainty is set, calculates the precision of the result
+          in accordance with the manual uncertainty set.
 
-        - ManualUncertainty set and Calculate Precision from Uncertainty
-          is also set in Analysis Service: calculates the precision of the
-          result according to the manual uncertainty set.
+        - If Calculate Precision from Uncertainty is set in Analysis Service,
+          calculates the precision in accordance with the uncertainty infered
+          from uncertainties ranges.
 
-        - ManualUncertainty set and Calculatet Precision from Uncertainty
-          not set in Analysis Service: returns the result as-is.
+        - If neither Manual Uncertainty nor Calculate Precision from
+          Uncertainty are set, returns the precision from the Analysis Service
 
         Further information at AbstractBaseAnalysis.getPrecision()
         """
-        allow_manual = self.getAllowedManualUncertainty()
+        allow_manual = self.getAllowManualUncertainty()
         precision_unc = self.getPrecisionFromUncertainty()
         if allow_manual or precision_unc:
             uncertainty = self.getUncertainty(result)


### PR DESCRIPTION


Once a result for a given Analysis is submitted, the system reformats the result in accordance with the value set in the field "Precision" (Precision as number of decimals) from the Analysis Service the Analysis comes from.

The same behavior happens, also if the option "Calculate Precision from Uncertainities" is checked. In this case, the system should automatically apply the precision based on the uncertainties. Excerpt for the mentioned field in "Analysis Service" edit view:

> Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set.

