### PR TITLE
NDEV-38 Sampling Round issues

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -263,7 +263,7 @@ function AnalysisRequestAddByCol() {
                     template_set(index);
                 });
                 // Writing the sampling date
-                $('input[id^="SamplingDate-"]:visible').val(spec['samplingRoundSamplingDate']);
+                $('input[id^="SamplingDate-"]:visible').val(spec['samplingRoundSamplingDate']+" 00:00");
                 // Hiding all fields which depends on the sampling round
                 var to_disable = ['Specification', 'SamplePoint', 'ReportDryMatter', 'Sample', 'Batch',
                     'SubGroup', 'SamplingDate', 'Composite', 'Profiles', 'DefaultContainerType', 'AdHoc'];

--- a/bika/lims/content/samplinground.py
+++ b/bika/lims/content/samplinground.py
@@ -160,7 +160,7 @@ class ISamplingRound(model.Schema):
                 title=_(u"Sampler"),
                 description=_(u"The default Sampler for these Sampling Round"),
                 required=True,
-                source=Samplers(['LabManager', 'Sampler']),
+                source=Samplers(['Sampler']),
                 )
 
         department = schema.Choice(


### PR DESCRIPTION
While creating an AR after creating a Sampling Round, system was returning an error because of wrong date format of Sampling Date. The problem was in SamplingRound.SamplingDate field which stored only the date, not the time. Replaced it with datetime.
Also removed 'LabManager's from 'Sampler's field.