### PR TITLE
NDEV-15 Render transition buttons only if show_workflow_action in view is true

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -48,6 +48,7 @@ class AnalysisServicesView(ASV):
 
         self.contentFilter['getPointOfCapture'] = poc
         self.contentFilter['inactive_state'] = 'active'
+        self.show_workflow_action_buttons = False
 
         if category:
             self.contentFilter['getCategoryTitle'] = category

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -157,9 +157,19 @@ function BikaListingTableView() {
 	* The process requires an ajax call, so the function keeps checkboxes
 	* disabled until the allowed transitions for the associated object are set.
 	*/
-	function load_transitions() {
+	function load_transitions(blisting='') {
 		"use strict";
-		if (loading_transitions) {
+		if (blisting == '') {
+            var blistings = $('table.bika-listing-table');
+            $(blistings).each(function(i) {
+                load_transitions($(this));
+            });
+            return;
+		}
+        var buttonspane = $(blisting).find('span.workflow_action_buttons');
+		if (loading_transitions || $(buttonspane).length == 0) {
+		    // If show_workflow_action_buttons param is set to False in the
+		    // view, or transitions are being loaded already, do nothing
 			return;
 		}
 		loading_transitions = true;
@@ -242,6 +252,12 @@ function BikaListingTableView() {
 	*/
 	function render_transition_buttons(blst) {
 		"use strict";
+        var buttonspane = $(blst).find('span.workflow_action_buttons');
+        if ($(buttonspane).length == 0) {
+		    // If show_workflow_action_buttons param is set to False in the
+		    // view, do nothing
+		    return;
+		}
 		var allowed_transitions = [];
 		var hidden_transitions = $(blst).find('input[type="hidden"][id="hide_transitions"]');
 		hidden_transitions = $(hidden_transitions).length == 1 ? $(hidden_transitions).val() : '';
@@ -279,7 +295,6 @@ function BikaListingTableView() {
 		}
 
 		// Generate the action buttons
-		var buttonspane = $(blst).find('span.workflow_action_buttons');
 		$(buttonspane).html('');
 		for (var i = 0; i < allowed_transitions.length; i++) {
 			var trans = allowed_transitions[i];


### PR DESCRIPTION
Transition buttons were always rendered when an item of the list was clicked. With this modif, the transition buttons footer is only rendered in lists if the param show_workflow_action_buttons of the view is set to true.

Also, the workflow action buttons are no longer displayed for the Analysis Service view from inside AR Add.