### PR TITLE
Typo error in HistoryAwareReferenceField

### DIFF
--- a/bika/lims/browser/fields/historyawarereferencefield.py
+++ b/bika/lims/browser/fields/historyawarereferencefield.py
@@ -3,23 +3,15 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from AccessControl import ClassSecurityInfo, Unauthorized
-from Products.ATExtensions.Extensions.utils import makeDisplayList
-from Products.ATExtensions.ateapi import RecordField, RecordsField
-from Products.Archetypes.Registry import registerField
-from Products.Archetypes.public import *
-from Products.CMFCore.utils import getToolByName
-from Products.CMFEditions.ArchivistTool import ArchivistRetrieveError
-from Products.validation import validation
-from Products.validation.validators.RegexValidator import RegexValidator
-import sys
-from Products.CMFEditions.Permissions import SaveNewVersion
-from Products.CMFEditions.Permissions import AccessPreviousVersions
+from AccessControl import ClassSecurityInfo
 from Products.Archetypes.config import REFERENCE_CATALOG
+from Products.Archetypes.public import *
+from Products.Archetypes.Registry import registerField
+from Products.CMFCore.utils import getToolByName
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
 from bika.lims import logger
 from bika.lims.utils import to_utf8
+import sys
 
 
 class HistoryAwareReferenceField(ReferenceField):
@@ -182,8 +174,9 @@ class HistoryAwareReferenceField(ReferenceField):
 
         if not self.multiValued:
             if len(rd) > 1:
-                log("%s references for non multivalued field %s of %s" %
-                    (len(rd), self.getName(), instance))
+                msg = "%s references for non multivalued field %s of %s" % \
+                    (len(rd), self.getName(), instance)
+                logger.warning(msg)
             if not aslist:
                 if rd:
                     rd = [rd[uid] for uid in rd.keys()][0]


### PR DESCRIPTION
Use ``logger.warning(`` instead of ``log(``