### PR TITLE
NDEV-40 Error invalidating a published test report (retract_ar action)

### DIFF
--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -659,3 +659,23 @@ def measure_time(func_to_measure):
         print log
         return return_value
     return wrap
+
+
+def copy_field_values(src, dst, ignore_fieldnames=None, ignore_fieldtypes=None):
+    ignore_fields = ignore_fieldnames if ignore_fieldnames else []
+    ignore_types = ignore_fieldtypes if ignore_fieldtypes else []
+    if 'id' not in ignore_fields:
+        ignore_fields.append('id')
+
+    src_schema = src.Schema()
+    dst_schema = dst.Schema()
+
+    for field in src_schema.fields():
+        fieldname = field.getName()
+        if fieldname in ignore_fields \
+                or field.type in ignore_types \
+                or fieldname not in dst_schema:
+            continue
+        value = field.get(src)
+        if value:
+            dst_schema[fieldname].set(dst, value)


### PR DESCRIPTION
When you invalidate a published test report (transition ``retract_ar``), the following error occurs:

```
Traceback (innermost last):
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module bika.lims.browser.analysisrequest.workflow, line 57, in _call_
Module bika.lims.browser.analysisrequest.workflow, line 497, in workflow_action_retract_ar
Module bika.lims.browser.analysisrequest.workflow, line 640, in cloneAR
AttributeError: setService
```

Also, created a new function to make the copy of objects easier.