### PR TITLE
NDEV-46 ARAdd: analyses don't get their dependants.

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -141,7 +141,6 @@ class AnalysisServicesView(ASV):
         # run multiple times.  This is necessary so that AR Add can check
         # the item count before choosing to render the table at all.
         if not self.ar_add_items:
-            bs = self.context.bika_setup
             # The parent folder can be a client or a batch, but we need the
             # client.  It is possible that this will be None!  This happens
             # when the AR is inside a batch, and the batch has no Client set.
@@ -149,12 +148,14 @@ class AnalysisServicesView(ASV):
             if not self.context.aq_parent.portal_type == "AnalysisRequestsFolder":
                 client = self.context.aq_parent if self.context.aq_parent.portal_type == 'Client'\
                     else self.context.aq_parent.getClient()
+            # TODO: Forcing the sort_on value. We should find a better way,
+            # this is just a quick fix.
+            self.contentFilter['sort_on'] = 'title'
             items = super(AnalysisServicesView, self).folderitems()
             for x, item in enumerate(items):
                 if 'obj' not in items[x]:
                     continue
                 obj = items[x]['obj']
-                kw = obj.getKeyword()
                 for arnum in range(self.ar_count):
                     key = 'ar.%s' % arnum
                     # If AR Specification fields are enabled, these should

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -1881,7 +1881,7 @@ function AnalysisRequestAddByCol() {
                         $("#singleservice").focus()
                     }
                     var title = $(this).parents("[title]").attr("title")
-                    deps_calc(arnum, [uid], false, title)
+                    deps_calc(arnum, [uid], true, title)
                     partition_indicators_set(arnum)
                     recalc_prices(arnum)
                 })
@@ -2048,10 +2048,11 @@ function AnalysisRequestAddByCol() {
                 var Dependencies = lims.AnalysisService.Dependencies(uid)
                 for (i = 0; i < Dependencies.length; i++) {
                     var Dep = Dependencies[i]
-                    dep_element = $("tr[uid='" + Dep['Service_uid'] + "'] " +
+                    dep_element = $("tr[uid='" + Dep + "'] " +
                                     "td[class*='ar\\." + arnum + "'] " +
                                     "input[type='checkbox']")
                     if (!$(dep_element).prop("checked")) {
+                        // not working because Dep is a uid
                         dep_titles.push(Dep['Service'])
                         dep_services.push(Dep)
                     }
@@ -2080,10 +2081,11 @@ function AnalysisRequestAddByCol() {
                 var Dependants = lims.AnalysisService.Dependants(uid)
                 for (i = 0; i < Dependants.length; i++) {
                     Dep = Dependants[i]
-                    dep_element = $("tr[uid='" + Dep['Service_uid'] + "'] " +
+                    dep_element = $("tr[uid='" + Dep + "'] " +
                                     "td[class*='ar\\." + arnum + "'] " +
                                     "input[type='checkbox']")
                     if ($(dep_element).prop("checked")) {
+                        // not working because Dep is a uid
                         dep_titles.push(Dep['Service'])
                         dep_services.push(Dep)
                     }
@@ -2111,6 +2113,7 @@ function AnalysisRequestAddByCol() {
 
     function dependants_remove_confirm(initiator, dep_services,
                                        dep_titles) {
+        // this function is not used!
         var d = $.Deferred()
         $("body").append(
           "<div id='messagebox' style='display:none' title='" + _("Service dependencies") + "'>" +
@@ -2144,7 +2147,7 @@ function AnalysisRequestAddByCol() {
     function dependants_remove_yes(arnum, dep_services) {
         for (var i = 0; i < dep_services.length; i += 1) {
             var Dep = dep_services[i]
-            var uid = Dep['Service_uid']
+            var uid = Dep
             analysis_cb_uncheck(arnum, uid)
         }
         _partition_indicators_set(arnum)
@@ -2163,6 +2166,7 @@ function AnalysisRequestAddByCol() {
          initiator_title is the dialog title, this could be a service but also could
          be "Dry Matter" or some other name
          */
+         // this function is not used!
         var d = $.Deferred()
         var html = "<div id='messagebox' style='display:none' title='" + _("Service dependencies") + "'>"
         html = html + _("<p>${service} requires the following services to be selected:</p>" +
@@ -2202,7 +2206,7 @@ function AnalysisRequestAddByCol() {
          */
         for (var i = 0; i < dep_services.length; i++) {
             var Dep = dep_services[i]
-            var uid = Dep['Service_uid']
+            var uid = Dep
             var dep_cb = $("tr[uid='" + uid + "'] " +
                            "td[class*='ar\\." + arnum + "'] " +
                            "input[type='checkbox']")
@@ -2214,12 +2218,10 @@ function AnalysisRequestAddByCol() {
                 }
             }
             else {
-                // create new row for all services we may need
-                singleservice_duplicate(Dep['Service_uid'],
-                                        Dep["Service"],
-                                        Dep["Keyword"],
-                                        Dep["Price"],
-                                        Dep["VAT"])
+//                TODO: We should create a function that gets the
+//                categories of the selected dependants. Expand those
+//                categories and selected the dependants.
+                expand_category_for_service(Dep)
             }
             // finally check the service
             analysis_cb_check(arnum, uid);
@@ -2613,4 +2615,13 @@ function AnalysisRequestAddByCol() {
         $('table tr th[id^="foldercontents-ar."]').css({'width':arcolswidth, 'text-align':'center'});
         $('table tr[id^="folder-contents-item-"] td[class*="ar"]').css({'width':arcolswidth, 'text-align':'center'});
     }
+}
+
+function expand_category_for_service(uid){
+
+    // Ajax getting the category uid
+
+    // Expand category by uid
+
+    // Wait until all services are loaded
 }

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -2237,7 +2237,7 @@ function AnalysisRequestAddByCol() {
                 }
             }
             else{
-                expand_category_for_service(Dep, arnum, uid);
+                expand_category_for_service(Dep, arnum);
             }
         }
         recalc_prices(arnum)

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -1783,17 +1783,21 @@ function AnalysisRequestAddByCol() {
             $(this).removeClass("expanded").addClass("collapsed")
         })
     }
-
-    function category_header_expand_handler(element) {
-        /* Deferred function to expand the category with ajax (or not!!)
-         on first expansion.  duplicated from bika.lims.bikalisting.js, this code
-         fires when categories are expanded automatically (eg, when profiles or templates require
-         that the category contents are visible for selection)
-
-         Also, this code returns deferred objects, not their promises.
-
-         :param: element - The category header TH element which normally receives 'click' event
-         */
+    /* Deferred function to expand the category with ajax (or not!!)
+    * on first expansion.  duplicated from bika.lims.bikalisting.js, this code
+    * fires when categories are expanded automatically (eg, when profiles or
+    * templates require
+    * that the category contents are visible for selection)
+    *
+    * Also, this code returns deferred objects, not their promises.
+    *
+    * @param {DOM Object} element - The category header TH element which
+    * normally receives 'click' event.
+    * @param {Number} arnum: the analysis request column number.
+    * @param {String} serv_uid: uid of the analysis service.
+    * @return {Object} deferred objects, not their promises.
+    */
+    function category_header_expand_handler(element, arnum, serv_uid) {
         var def = $.Deferred()
         // with form_id allow multiple ajax-categorised tables in a page
         var form_id = $(element).parents("[form_id]").attr("form_id")
@@ -1833,6 +1837,12 @@ function AnalysisRequestAddByCol() {
                     $("[form_id='" + form_id + "'] tr[data-ajax_category='" + cat_title + "']").replaceWith(rows);
                     $(element).removeClass("collapsed").addClass("expanded");
                     specification_apply();
+                    // If service data defined, set the checkbox
+                    if (arnum !== undefined && serv_uid !== undefined){
+                        analysis_cb_check(arnum, serv_uid);
+                        recalc_prices(arnum);
+                        _partition_indicators_set(arnum);
+                    }
                     def.resolve();
                 })
         }
@@ -1840,6 +1850,12 @@ function AnalysisRequestAddByCol() {
             // When ajax_categories are disabled, all cat items exist as TR elements:
             $(element).parent().nextAll("tr[cat='" + cat_title + "']").toggle(true)
             $(element).removeClass("collapsed").addClass("expanded")
+            // If service data defined, set the checkbox
+            if (arnum !== undefined && serv_uid !== undefined){
+                analysis_cb_check(arnum, serv_uid);
+                recalc_prices(arnum);
+                _partition_indicators_set(arnum);
+            }
             def.resolve()
         }
         return def
@@ -2216,15 +2232,13 @@ function AnalysisRequestAddByCol() {
                     // skip if checked already
                     continue
                 }
+                else {
+                    analysis_cb_check(arnum, uid);
+                }
             }
-            else {
-//                TODO: We should create a function that gets the
-//                categories of the selected dependants. Expand those
-//                categories and selected the dependants.
-                expand_category_for_service(Dep)
+            else{
+                expand_category_for_service(Dep, arnum, uid);
             }
-            // finally check the service
-            analysis_cb_check(arnum, uid);
         }
         recalc_prices(arnum)
         _partition_indicators_set(arnum)
@@ -2615,13 +2629,35 @@ function AnalysisRequestAddByCol() {
         $('table tr th[id^="foldercontents-ar."]').css({'width':arcolswidth, 'text-align':'center'});
         $('table tr[id^="folder-contents-item-"] td[class*="ar"]').css({'width':arcolswidth, 'text-align':'center'});
     }
-}
 
-function expand_category_for_service(uid){
+    /**
+    * Given an analysis service UID, this function expands the category for
+    * that service and selects it.
+    * @param {String} serv_uid: uid of the analysis service.
+    * @param {Number} arnum: the analysis request column number.
+    * @return {None} nothing.
+    */
+    function expand_category_for_service(serv_uid, arnum){
 
-    // Ajax getting the category uid
-
-    // Expand category by uid
-
-    // Wait until all services are loaded
+        // Ajax getting the category from uid
+        var request_data = {
+            catalog_name: "uid_catalog",
+            UID: serv_uid,
+            include_methods: 'getCategoryTitle',
+        };
+        window.bika.lims.jsonapi_read(request_data, function(data) {
+            if (data.objects.length < 1 ) {
+               var msg =
+                   '[bika.lims.analysisrequest.add_by_col.js] No data returned ' +
+                   'while running "expand_category_for_service" for ' + serv_uid;
+               console.warn(msg);
+               window.bika.lims.warning(msg);
+            } else {
+                var cat_title = data.objects[0].getCategoryTitle;
+                // Expand category by uid and select the service
+                var element = $("th[cat='" + cat_title + "']");
+                category_header_expand_handler(element, arnum, serv_uid);
+            }
+        });
+    }
 }

--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -610,14 +610,26 @@ function AnalysisRequestAnalysesView() {
         }
 
     }
-
+    /**
+    * Given a selected service, this function selects the dependencies for
+    * the selected service.
+    * @param {String} dlg: The dialog to display (Not working!)
+    * @param {DOM object} element: The checkbox object.
+    * @param {Object} dep_services: A list of UIDs.
+    * @return {None} nothing.
+    */
     function add_Yes(dlg, element, dep_services){
-    var service_uid;
+        var service_uid, dep_cb;
         for(var i = 0; i<dep_services.length; i++){
             service_uid = dep_services[i];
-            if(! $("#list_cb_"+service_uid).prop("checked") ){
-                check_service(service_uid);
-                $("#list_cb_"+service_uid).prop("checked",true);
+            dep_cb = $("#list_cb_"+service_uid);
+            if(dep_cb.length > 0){
+                if(!$(dep_cb).prop("checked")){
+                    check_service(service_uid);
+                    $("#list_cb_"+service_uid).prop("checked",true);
+                }
+            }else{
+                expand_category_for_service(service_uid);
             }
         }
         if(dlg !== false){
@@ -754,5 +766,39 @@ function AnalysisRequestAnalysesView() {
                 }
             }
         }
+    }
+    /**
+    * Given an analysis service UID, this function expands the category for
+    * that service and selects it.
+    * @param {String} serv_uid: uid of the analysis service.
+    * @return {None} nothing.
+    */
+    function expand_category_for_service(serv_uid){
+        // Ajax getting the category from uid
+        var request_data = {
+            catalog_name: "uid_catalog",
+            UID: serv_uid,
+            include_methods: 'getCategoryTitle',
+        };
+        window.bika.lims.jsonapi_read(request_data, function(data) {
+            if (data.objects.length < 1 ) {
+               var msg =
+                   '[bika.lims.analysisrequest.add_by_col.js] No data returned ' +
+                   'while running "expand_category_for_service" for ' + serv_uid;
+               console.warn(msg);
+               window.bika.lims.warning(msg);
+            } else {
+                var cat_title = data.objects[0].getCategoryTitle;
+                // Expand category by uid and select the service
+                var element = $("th[cat='" + cat_title + "']");
+                //category_header_expand_handler(element, arnum, serv_uid);
+                window.bika.lims.BikaListingTableView
+                .category_header_expand_handler(element).done(
+                    function(){
+                    check_service(serv_uid);
+                    $("#list_cb_"+serv_uid).prop("checked",true);
+                });
+            }
+        });
     }
 }

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -360,7 +360,7 @@ function BikaListingTableView() {
 		// expand/collapse categorised rows
 		$(".bika-listing-table th.collapsed").live("click", function () {
 			if (!$(this).hasClass("ignore_bikalisting_default_handler")){
-				category_header_expand_handler(this)
+				that.category_header_expand_handler(this)
 			}
 		});
         $(".bika-listing-table th.expanded").live("click", function () {
@@ -379,7 +379,7 @@ function BikaListingTableView() {
         })
     }
 
-	function category_header_expand_handler(element) {
+	that.category_header_expand_handler = function (element) {
 		// element is the category header TH.
 		// duplicated in bika.lims.analysisrequest.add_by_col.js
 		var def = $.Deferred()


### PR DESCRIPTION
This PR forces the sort index on the Analysis Services displayed in ARAdd. It also fixes the following bug:

- When the user selects services with a dependent under another category, this dependent is not selected.