### PR TITLE
NDEV-48 After entering a result, the checkbox is automatically checked, but action buttons do not appear

### DIFF
--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -323,10 +323,13 @@ function BikaListingTableView() {
 				event.preventDefault()
 			}
 			// check the item's checkbox
-			var form_id = $(this).parents("form").attr("id")
-			var uid = $(this).attr("uid")
-			if (!($("#" + form_id + "_cb_" + uid).prop("checked"))) {
-				$("#" + form_id + "_cb_" + uid).prop("checked", true)
+			var uid = $(this).attr("uid");
+			var tr = $(this).parents('tr#folder-contents-item-'+uid);
+			var checkbox = tr.find('input[id$="_cb_' + uid +'"]');
+			if ($(checkbox).length == 1) {
+                var blst = $(checkbox).parents("table.bika-listing-table");
+                $(checkbox).prop('checked', true);
+                render_transition_buttons(blst);
 			}
 		})
 	}
@@ -334,11 +337,13 @@ function BikaListingTableView() {
 	function listing_string_select_changed() {
 		// always select checkbox when selectable listing item is changed
 		$(".listing_select_entry").live("change", function () {
-			form_id = $(this).parents("form").attr("id")
-			uid = $(this).attr("uid")
-			// check the item's checkbox
-			if (!($("#" + form_id + "_cb_" + uid).prop("checked"))) {
-				$("#" + form_id + "_cb_" + uid).prop("checked", true)
+			var uid = $(this).attr("uid");
+			var tr = $(this).parents('tr#folder-contents-item-'+uid);
+			var checkbox = tr.find('input[id$="_cb_' + uid +'"]');
+			if ($(checkbox).length == 1) {
+			    var blst = $(checkbox).parents("table.bika-listing-table");
+			    $(checkbox).prop("checked", true);
+			    render_transition_buttons(blst);
 			}
 		})
 	}


### PR DESCRIPTION
As per the new way of rendering action buttons at the bottom of the list, when the user enters a result, although the row gets selected (its checkbox), the action buttons bar at the bottom do not get rendered. So, the user must manually uncheck and check again to see the action buttons.
