### PR TITLE
NMRL-345 Instrument QC Viewlet failure

### DIFF
--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -17,6 +17,7 @@ from bika.lims import bikaMessageFactory as _, logger
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils import formatDecimalMark
+from bika.lims.utils import to_unicode
 
 
 def duplicateAnalysis(analysis):
@@ -449,7 +450,7 @@ def get_method_instrument_constraints(context, uids):
             tprem = ''.join(premises)
 
             fiuid = v_instrs[0] if v_instrs else ''
-            instrtitle = a_dinstrum.Title() if a_dinstrum else ''
+            instrtitle = to_unicode(a_dinstrum.Title()) if a_dinstrum else ''
             iinstrs = ', '.join([i.Title() for i in instrs
                                  if i.UID() not in v_instrs])
             dmeth = method.Title() if method else ''

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -451,9 +451,9 @@ def get_method_instrument_constraints(context, uids):
 
             fiuid = v_instrs[0] if v_instrs else ''
             instrtitle = to_unicode(a_dinstrum.Title()) if a_dinstrum else ''
-            iinstrs = ', '.join([i.Title() for i in instrs
+            iinstrs = ', '.join([to_unicode(i.Title()) for i in instrs
                                  if i.UID() not in v_instrs])
-            dmeth = method.Title() if method else ''
+            dmeth = to_unicode(method.Title()) if method else ''
             m1 = _("Invalid instruments are not displayed: %s") % iinstrs
             m2 = _("Default instrument %s is not valid") % instrtitle
             m3 = _("No valid instruments available: %s ") % iinstrs


### PR DESCRIPTION
Instrument viewlet which contains information about failed and expired instruments failed a few times due to null bika_setup_catalog. It could happen when running the instance for the first time.
However, while checking this issue, we saw that it is necessary to convert to unicode Instrument Titles thus they can contain special characters.