### PR TITLE
NMRL-372 Nonetype value has no attribute getPrefix

### DIFF
--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -425,6 +425,14 @@ class ajaxAnalysisRequestSubmit():
                     required.remove('SamplingDate')
                 if 'SampleType' in required:
                     required.remove('SampleType')
+            # If this is not a Secondary AR, make sure that Sample Type UID is valid. This shouldn't
+            # happen, but making sure just in case.
+            else:
+                st_uid = state.get('SampleType', None)
+                if not st_uid or not bsc(portal_type='SampleType', UID=st_uid):
+                    msg = t(_("Not a valid Sample Type."))
+                    ajax_form_error(self.errors, arnum=arnum, message=msg)
+                    continue
             # checking if sampling date is not future
             if state.get('SamplingDate', ''):
                 samplingdate = state.get('SamplingDate', '')


### PR DESCRIPTION
While creating an AR, if Sample Type UID is not found in uid_catalog it is set to 'None'. Then it causes and error while generating prefix. To avoid this, added Sample Type UID validator to creation method.