### PR TITLE
In some cases, the sampler defined in reports were wrong

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -36,6 +36,7 @@ from bika.lims.utils import attachPdf, createPdf, encode_header, \
 from bika.lims.utils import formatDecimalMark, to_utf8
 from bika.lims.utils.analysis import format_uncertainty
 from bika.lims.vocabularies import getARReportTemplates
+from bika.lims.workflow import getCurrentState
 from bika.lims.workflow import wasTransitionPerformed
 from plone.api.portal import get_registry_record
 from plone.api.portal import set_registry_record
@@ -718,7 +719,8 @@ class AnalysisRequestDigester:
         self.request = ar.REQUEST
 
         # if AR was previously digested, use existing data (if exists)
-        if not overwrite:
+        verified = wasTransitionPerformed(ar, 'verify')
+        if not overwrite and verified:
             # Prevent any error related with digest
             data = ar.getDigest() if hasattr(ar, 'getDigest') else {}
             if data:
@@ -1063,7 +1065,7 @@ class AnalysisRequestDigester:
             memail = member.getProperty('email')
             mhomepage = member.getProperty('home_page')
             pc = getToolByName(self.context, 'portal_catalog')
-            contact = pc(portal_type='LabContact', getUsername=member.id)
+            contact = pc(portal_type='LabContact', getUsername=member.getId())
             # Only one LabContact should be found
             if len(contact) > 1:
                 logger.warn(

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -36,7 +36,6 @@ from bika.lims.utils import attachPdf, createPdf, encode_header, \
 from bika.lims.utils import formatDecimalMark, to_utf8
 from bika.lims.utils.analysis import format_uncertainty
 from bika.lims.vocabularies import getARReportTemplates
-from bika.lims.workflow import getCurrentState
 from bika.lims.workflow import wasTransitionPerformed
 from plone.api.portal import get_registry_record
 from plone.api.portal import set_registry_record


### PR DESCRIPTION
It was because some member objects didn't have the '.id' attribute.
Also, this PR forces the system to digest only after the verification of the AR.