### PR TITLE
Defining the correct indexes to sort on in batch

### DIFF
--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -40,11 +40,14 @@ class BatchFolderContentsView(BikaListingView):
         self.pagesize = 25
 
         self.columns = {
-            'Title': {'title': _('Title')},
-            'BatchID': {'title': _('Batch ID')},
-            'Description': {'title': _('Description')},
+            'Title': {'title': _('Title'),
+                      'index': 'title'},
+            'BatchID': {'title': _('Batch ID'),
+                        'index': 'getId'},
+            'Description': {'title': _('Description'), 'sortable': False},
             'BatchDate': {'title': _('Date')},
-            'Client': {'title': _('Client')},
+            'Client': {'title': _('Client'),
+                       'index': 'getClientTitle'},
             'state_title': {'title': _('State'), 'sortable': False},
             'created': {'title': _('Created'), },
         }


### PR DESCRIPTION
Sorting on columns wasn't working because it was sorting on wrong columns.