### PR TITLE
Allow direct verification of analyses with dependencies in manage results view

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -1005,11 +1005,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return False
 
         # Check if the analysis has dependencies not yet verified
+        # Commented because we want the transition verify to appear when an
+        # analysis with dependencies is selected in manage results view. The
+        # after transition event will be in charge to deal with dependencies.
         for d in self.getDependencies():
-            review_state = workflow.getInfoFor(d, "review_state")
-            if review_state in (
-                    "to_be_sampled", "to_be_preserved", "sample_due",
-                    "sample_received", "attachment_due", "to_be_verified"):
+            if not d.isVerifiable() \
+                    and not wasTransitionPerformed(d, 'verify'):
                 return False
 
         # All checks passsed

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -1004,16 +1004,17 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         if review_state != 'to_be_verified':
             return False
 
-        # Check if the analysis has dependencies not yet verified
-        # Commented because we want the transition verify to appear when an
-        # analysis with dependencies is selected in manage results view. The
-        # after transition event will be in charge to deal with dependencies.
+        # If the analysis has at least one dependency that hasn't been verified
+        # yet and because of its current state cannot be verified, then return
+        # false. The idea is that an analysis that requires from results of
+        # other analyses cannot be verified unless all its dependencies have
+        # already been verified or are in a suitable state for doing so.
         for d in self.getDependencies():
             if not d.isVerifiable() \
                     and not wasTransitionPerformed(d, 'verify'):
                 return False
 
-        # All checks passsed
+        # All checks passed
         return True
 
     # TODO Workflow, Analysis - Move to analysis.guard.verify?

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -528,7 +528,7 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
 
             # All dependencies from this dependent analysis are ok?
             deps = dependent.getDependencies()
-            dsub = [dep for dep in deps if wasTransitionPerformed(sp, 'submit')]
+            dsub = [dep for dep in deps if wasTransitionPerformed(dep, 'submit')]
             if len(deps) == len(dsub):
                 # The statuses of all dependencies of this dependent are ok
                 # (at least, all of them have been submitted already)

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -79,6 +79,11 @@ def after_verify(obj):
     This function is called automatically by
     bika.lims.workfow.AfterTransitionEventHandler
     """
+
+    # If the analysis has dependencies, transition them
+    for dependency in obj.getDependencies():
+        doActionFor(dependency, 'verify')
+
     # Do all the reflex rules process
     obj._reflex_rule_process('verify')
 


### PR DESCRIPTION
As per [Dynamic loading of allowed transitions in lists](https://github.com/naralabs/bika.lims/pull/150), when the user selects all analyses from a manage results view, the transition bar that gets rendered at the bottom of the list after items selection only displays the transitions/actions that can be performed to all items selected. So, if two analyses both in state to_be_verified, but one of them has dependencies (requires other analyses for the auto-calculation of its result), only the transition "Retract" is displayed, regardless that one of the analyses is, in fact, in a suitable state for the transition "Verify" being performed. Thus, the system renders the intersection of the transitions that can apply to all items selected.

At this moment, the guard for the "Verify" transition of an analysis, checks if all its dependencies have been already verified. Otherwise, it returns False. As a result, when selecting an analysis with dependencies in manage results view, the button "Verify" will appear only if its dependencies have been transitioned already. Although strictly speaking the behavior is correct, users find annoying, cause 1) they have to select all items with no dependencies manually and 2) they have to select later the analysis with dependencies and transition it manually apart from the rest.

With this pull request, the "Verify" guard has been modified so an analysis with dependencies can be verified if all its dependencies are in a suitable state for being verified or have already been verified. This makes the "Verify" button to be rendered without losing the restrictive conditions imposed by having dependencies. 

To guarantee the consistency, this pull request also triggers the transition "Verify" for all dependencies when an analysis with dependencies is transitioned.