### PR TITLE
NDEV-60 Status inconsistences in Analyses in secondary Analysis Requests

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -1472,6 +1472,7 @@ function AnalysisRequestAddByCol() {
                       '_authenticator': $('input[name="_authenticator"]').val()
                   },
                   function (data) {
+                      var filled = [];
                       for (var i = 0; i < data.length; i++) {
                           var fieldname = data[i][0];
                           var fieldvalue = data[i][1];
@@ -1482,6 +1483,13 @@ function AnalysisRequestAddByCol() {
                               var element = $('#' + fieldname + '-' + arnum)[0]
                               $(element).attr('uid', fieldvalue)
                               $(element).val(fieldvalue)
+                              // Sometimes, there are both <fieldname_uid> and
+                              // <fieldname> keys in the data dictionary. In
+                              // those cases, the field that ends with '_uid'
+                              // gets preference over the field that doeesn't
+                              // ends with '_uid' when setting the state value.
+                              filled.push(fieldname);
+                              state_set(arnum, fieldname, fieldvalue);
                           }
                           // This
                           else {
@@ -1518,7 +1526,14 @@ function AnalysisRequestAddByCol() {
                                   default:
                                       console.log('Unhandled field type for field ' + fieldname + ': ' + element.type)
                               }
-                              state_set(arnum, fieldname, fieldvalue)
+                              if (filled.indexOf(fieldname) === -1) {
+                                  // Sometimes, there are both <fieldname_uid> and
+                                  // <fieldname> keys in the data dictionary. In
+                                  // those cases, the field that ends with '_uid'
+                                  // gets preference over the field that doeesn't
+                                  // ends with '_uid' when setting the state value.
+                                  state_set(arnum, fieldname, fieldvalue);
+                              }
                           }
                       }
                   })

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -361,6 +361,8 @@ function AnalysisRequestAddByCol() {
         uids = [uid, $("#bika_setup").attr("bika_analysisspecs_uid")]
         element = $("tr[fieldname=Specification] td[arnum=" + arnum + "] input")[0]
         filter_combogrid(element, "getClientUID", uids)
+        element = $("tr[fieldname=Sample] td[arnum=" + arnum + "] input")[0]
+        filter_combogrid(element, "getClientUID", uids);
     }
     /**
     * If client only has one contact, then Auto-complete the Contact field.

--- a/bika/lims/content/sample.py
+++ b/bika/lims/content/sample.py
@@ -853,6 +853,12 @@ class Sample(BaseFolder, HistoryAwareMixin):
             prep_workflows.append([workflow_id, workflow.title])
         return DisplayList(prep_workflows)
 
+    def getSamplePartitions(self):
+        """Returns the Sample Partitions associated to this Sample
+        """
+        partitions = self.objectValues('SamplePartition')
+        return partitions
+
     @deprecated('[1705] Use events.after_no_sampling_workflow from '
                 'bika.lims.workflow.sample')
     @security.public

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -108,6 +108,7 @@ def create_analysisrequest(client, request, values, analyses=None,
                 analyses
             )
 
+    import pdb;pdb.set_trace()
     # At this point, we have a fully created AR, with a Sample, Partitions and
     # Analyses, but the state of all them is the initial ("sample_registered").
     # We can now transition the whole thing (instead of doing it manually for

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -95,11 +95,11 @@ def create_analysisrequest(client, request, values, analyses=None,
         partitions = [{'services': service_uids}]
 
     part_num = 0
+    prefix = sample.getId() + "-P"
     if secondary:
         # Always create new partitions if is a Secondary AR, cause it does
         # not make sense to reuse the partitions used in a previous AR!
         sparts = sample.getSamplePartitions()
-        prefix = sample.getId() + "-P"
         for spart in sparts:
             spartnum = int(spart.getId().split(prefix)[1])
             if spartnum > part_num:
@@ -107,8 +107,7 @@ def create_analysisrequest(client, request, values, analyses=None,
 
     for n, partition in enumerate(partitions):
         # Calculate partition id
-        partition_prefix = sample.getId() + "-P"
-        partition_id = '%s%s' % (partition_prefix, part_num + 1)
+        partition_id = '%s%s' % (prefix, part_num + 1)
         partition['part_id'] = partition_id
         # Point to or create sample partition
         if partition_id in sample.objectIds():

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -93,10 +93,22 @@ def create_analysisrequest(client, request, values, analyses=None,
     # Create sample partitions
     if not partitions:
         partitions = [{'services': service_uids}]
+
+    part_num = 0
+    if secondary:
+        # Always create new partitions if is a Secondary AR, cause it does
+        # not make sense to reuse the partitions used in a previous AR!
+        sparts = sample.getSamplePartitions()
+        prefix = sample.getId() + "-P"
+        for spart in sparts:
+            spartnum = int(spart.getId().split(prefix)[1])
+            if spartnum > part_num:
+                part_num = spartnum
+
     for n, partition in enumerate(partitions):
         # Calculate partition id
         partition_prefix = sample.getId() + "-P"
-        partition_id = '%s%s' % (partition_prefix, n + 1)
+        partition_id = '%s%s' % (partition_prefix, part_num + 1)
         partition['part_id'] = partition_id
         # Point to or create sample partition
         if partition_id in sample.objectIds():
@@ -107,8 +119,8 @@ def create_analysisrequest(client, request, values, analyses=None,
                 partition,
                 analyses
             )
+        part_num += 1
 
-    import pdb;pdb.set_trace()
     # At this point, we have a fully created AR, with a Sample, Partitions and
     # Analyses, but the state of all them is the initial ("sample_registered").
     # We can now transition the whole thing (instead of doing it manually for
@@ -128,7 +140,11 @@ def create_analysisrequest(client, request, values, analyses=None,
         # children) to fit with the Sample Partition's current state
         sampleactions = getReviewHistoryActionsList(sample)
         doActionsFor(ar, sampleactions)
-
+        # We need to transition the partition manually
+        # Transition pre-preserved partitions
+        for partition in partitions:
+            part = partition['object']
+            doActionsFor(part, sampleactions)
     else:
         # If Preservation is required for some partitions, and the SamplingWorkflow
         # is disabled, we need to transition to to_be_preserved manually.
@@ -148,18 +164,16 @@ def create_analysisrequest(client, request, values, analyses=None,
                 doActionFor(p, 'sample_due')
             doActionFor(sample, lowest_state)
 
-        # Transition pre-preserved partitions
-        for p in partitions:
-            if 'prepreserved' in p and p['prepreserved']:
-                part = p['object']
-                state = workflow.getInfoFor(part, 'review_state')
-                if state == 'to_be_preserved':
-                    doActionFor(part, 'preserve')
+    # Transition pre-preserved partitions
+    for p in partitions:
+        if 'prepreserved' in p and p['prepreserved']:
+            part = p['object']
+            doActionFor(part, 'preserve')
 
-        # Once the ar is fully created, check if there are rejection reasons
-        reject_field = values.get('RejectionReasons', '')
-        if reject_field and reject_field.get('checkbox', False):
-            doActionFor(ar, 'reject')
+    # Once the ar is fully created, check if there are rejection reasons
+    reject_field = values.get('RejectionReasons', '')
+    if reject_field and reject_field.get('checkbox', False):
+        doActionFor(ar, 'reject')
 
     return ar
 


### PR DESCRIPTION
When an Analysis Request is created by reusing a previously generated Sample (Secondary Analysis Request), the Analyses remains in "sample_registered". Their status should be "sample_due" if sampling workflow is enabled or "to_be_sampled" if the sampling workflow is disabled:

![ndev60](https://user-images.githubusercontent.com/832627/29007567-200da748-7b06-11e7-8b61-469960e8b054.png)

With this Pull Request, the function responsible of creating an Analysis Request based on the parameters set in the AR Add form checks if is a Secondary AR and in such case, the system tries to 
1) automatically transition the AR to the same state as the original Sample
2) Create new Sample Partition(s) for the new AR (it doesn't make sense to reuse previous partition/s)
3) automatically transition each Sample Partition (along with their analyses) to the state that matches better with the state of the previously created Sample.

With this PR, a bad behavior when trying to calculate the partitions for a given SampleType via ajax has been fixed. The system was trying to obtain a SampleType by using its title instead of the UID.

