### PR TITLE
NDEV-61 All Samples displayed in AR Add Form

### DIFF
--- a/bika/lims/adapters/referencewidgetvocabulary.py
+++ b/bika/lims/adapters/referencewidgetvocabulary.py
@@ -7,6 +7,7 @@ from bika.lims.permissions import *
 from bika.lims.utils import to_utf8 as _c
 from bika.lims.utils import to_unicode as _u
 from bika.lims.interfaces import IReferenceWidgetVocabulary
+from Products.AdvancedQuery import And, Or, MatchRegexp, Generic
 from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
 import json
@@ -21,7 +22,7 @@ class DefaultReferenceWidgetVocabulary(object):
 
     def __call__(self, result=None, specification=None, **kwargs):
         searchTerm = _c(self.request.get('searchTerm', '')).lower()
-        force_all = self.request.get('force_all', 'true')
+        force_all = self.request.get('force_all', 'false')
         searchFields = 'search_fields' in self.request \
             and json.loads(_u(self.request.get('search_fields', '[]'))) \
             or ('Title',)
@@ -33,34 +34,72 @@ class DefaultReferenceWidgetVocabulary(object):
         # first with all queries
         contentFilter = dict((k, v) for k, v in base_query.items())
         contentFilter.update(search_query)
-        try:
-            brains = catalog(contentFilter)
-        except:
-            from bika.lims import logger
-            logger.info(contentFilter)
-            raise
-        if brains and searchTerm:
-            _brains = []
-            if len(searchFields) == 0 \
-                    or (len(searchFields) == 1 and searchFields[0] == 'Title'):
-                _brains = [p for p in brains
-                           if p.Title.lower().find(searchTerm) > -1]
-            else:
-                for p in brains:
-                    for fieldname in searchFields:
-                        value = getattr(p, fieldname, None)
-                        if not value:
-                            instance = p.getObject()
-                            schema = instance.Schema()
-                            if fieldname in schema:
-                                value = schema[fieldname].get(instance)
-                        if callable(value):
-                            value = value()
-                        if value and value.lower().find(searchTerm) > -1:
-                            _brains.append(p)
-                            break
 
+        # Sorted by? (by default, Title)
+        sort_on = self.request.get('sidx', 'Title')
+        if sort_on == 'Title':
+            sort_on = 'sortable_title'
+        if sort_on:
+            # Check if is an index and if is sortable. Otherwise, assume the
+            # sorting must be done manually
+            index = catalog.Indexes.get(sort_on, None)
+            if index and index.meta_type in ['FieldIndex', 'DateIndex']:
+                contentFilter['sort_on'] = sort_on
+                # Sort order?
+                sort_order = self.request.get('sord', 'asc')
+                if (sort_order in ['desc', 'reverse', 'rev', 'descending']):
+                    contentFilter['sort_order'] = 'descending'
+                else:
+                    contentFilter['sort_order'] = 'ascending'
+
+        # Can do a search for indexes?
+        criterias = []
+        fields_wo_index = []
+        if searchTerm:
+            for field_name in searchFields:
+                index = catalog.Indexes.get(field_name, None)
+                if not index:
+                    fields_wo_index.append(field_name)
+                if index.meta_type in ('ZCTextIndex'):
+                    searchTerm += '*'
+                    criterias.append(MatchRegexp(field_name, searchTerm))
+                elif index.meta_type in ('FieldIndex'):
+                    criterias.append(MatchRegexp(field_name, searchTerm))
+                elif index.meta_type == 'DateIndex':
+                    msg = "Unhandled DateIndex search on '%s'" % field_name
+                    from bika.lims import logger
+                    logger.warn(msg)
+                else:
+                    criterias.append(Generic(field_name, searchTerm))
+
+        if criterias:
+            # Advanced search
+            advanced_query = catalog.makeAdvancedQuery(contentFilter)
+            aq_or = Or()
+            for criteria in criterias:
+                aq_or.addSubquery(criteria)
+            advanced_query &= aq_or
+            brains = catalog.evalAdvancedQuery(advanced_query)
+        else:
+            brains = catalog(contentFilter)
+
+        if brains and searchTerm and fields_wo_index:
+            _brains = []
+            for brain in brains:
+                for field_name in fields_wo_index:
+                    value = getattr(brain, field_name, None)
+                    if not value:
+                        instance = brain.getObject()
+                        schema = instance.Schema()
+                        if field_name in schema:
+                            value = schema[field_name].get(instance)
+                    if callable(value):
+                        value = value()
+                    if value and value.lower().find(searchTerm) > -1:
+                        _brains.append(brain)
+                        break
             brains = _brains
+
         # Then just base_query alone ("show all if no match")
         if not brains and force_all.lower() == 'true':
             if search_query:
@@ -70,4 +109,5 @@ class DefaultReferenceWidgetVocabulary(object):
                                if p.Title.lower().find(searchTerm) > -1]
                     if _brains:
                         brains = _brains
+
         return brains

--- a/bika/lims/adapters/referencewidgetvocabulary.py
+++ b/bika/lims/adapters/referencewidgetvocabulary.py
@@ -60,9 +60,10 @@ class DefaultReferenceWidgetVocabulary(object):
                 index = catalog.Indexes.get(field_name, None)
                 if not index:
                     fields_wo_index.append(field_name)
+                    continue
                 if index.meta_type in ('ZCTextIndex'):
-                    searchTerm += '*'
-                    criterias.append(MatchRegexp(field_name, searchTerm))
+                    temp_st = searchTerm + '*'
+                    criterias.append(MatchRegexp(field_name, temp_st))
                 elif index.meta_type in ('FieldIndex'):
                     criterias.append(MatchRegexp(field_name, searchTerm))
                 elif index.meta_type == 'DateIndex':

--- a/bika/lims/browser/analysisrequest/__init__.py
+++ b/bika/lims/browser/analysisrequest/__init__.py
@@ -85,30 +85,6 @@ class ClientContactVocabularyFactory(CatalogVocabulary):
         )
 
 
-class ReferenceWidgetVocabulary(DefaultReferenceWidgetVocabulary):
-
-    def __call__(self):
-        base_query = json.loads(self.request['base_query'])
-        # In client context, restrict samples to client samples only
-        if 'portal_type' in base_query \
-        and (base_query['portal_type'] == 'Sample'
-             or base_query['portal_type'][0] == 'Sample'):
-            client_uid = self.get_client_uid()
-            if client_uid:
-                base_query['getClientUID'] = client_uid
-                self.request['base_query'] = json.dumps(base_query)
-        return DefaultReferenceWidgetVocabulary.__call__(self)
-
-    def get_client_uid(self):
-        instance = self.context.aq_parent
-        while not IPloneSiteRoot.providedBy(instance):
-            if IClient.providedBy(instance):
-                return instance.UID()
-            if IBatch.providedBy(instance):
-                client = instance.getClient()
-                if client:
-                    return client.UID()
-
 class JSONReadExtender(object):
 
     """- Adds the full details of all analyses to the AR.Analyses field

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -12,13 +12,6 @@
     />
 
     <adapter
-      factory="bika.lims.browser.analysisrequest.ReferenceWidgetVocabulary"
-      provides="bika.lims.interfaces.IReferenceWidgetVocabulary"
-      for="bika.lims.interfaces.IAnalysisRequest
-           zope.publisher.interfaces.browser.IBrowserRequest"
-    />
-
-    <adapter
       factory="bika.lims.browser.analysisrequest.JSONReadExtender"
       provides="bika.lims.interfaces.IJSONReadExtender"
     />

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -1472,6 +1472,7 @@ function AnalysisRequestAddByCol() {
                       '_authenticator': $('input[name="_authenticator"]').val()
                   },
                   function (data) {
+                      var filled = [];
                       for (var i = 0; i < data.length; i++) {
                           var fieldname = data[i][0];
                           var fieldvalue = data[i][1];
@@ -1482,6 +1483,13 @@ function AnalysisRequestAddByCol() {
                               var element = $('#' + fieldname + '-' + arnum)[0]
                               $(element).attr('uid', fieldvalue)
                               $(element).val(fieldvalue)
+                              // Sometimes, there are both <fieldname_uid> and
+                              // <fieldname> keys in the data dictionary. In
+                              // those cases, the field that ends with '_uid'
+                              // gets preference over the field that doeesn't
+                              // ends with '_uid' when setting the state value.
+                              filled.push(fieldname);
+                              state_set(arnum, fieldname, fieldvalue);
                           }
                           // This
                           else {
@@ -1518,7 +1526,14 @@ function AnalysisRequestAddByCol() {
                                   default:
                                       console.log('Unhandled field type for field ' + fieldname + ': ' + element.type)
                               }
-                              state_set(arnum, fieldname, fieldvalue)
+                              if (filled.indexOf(fieldname) === -1) {
+                                  // Sometimes, there are both <fieldname_uid> and
+                                  // <fieldname> keys in the data dictionary. In
+                                  // those cases, the field that ends with '_uid'
+                                  // gets preference over the field that doeesn't
+                                  // ends with '_uid' when setting the state value.
+                                  state_set(arnum, fieldname, fieldvalue);
+                              }
                           }
                       }
                   })

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -341,6 +341,18 @@ function AnalysisRequestAddByCol() {
          */
         var element,uids
         var uid = $($("tr[fieldname='Client'] td[arnum='" + arnum + "'] input")[0]).attr("uid")
+        var client_set = uid !== undefined && uid != '';
+        var elements = ['Contact', 'CCContact', 'InvoiceContact',
+                        'SamplePoint', 'Template', 'Profiles',
+                        'Specification', 'Sample']
+        for (var i=0; i<elements.length; i++) {
+            element = $("tr[fieldname="+elements[i]+"] td[arnum=" + arnum + "] input")[0];
+            $(element).prop('disabled', !client_set);
+        }
+        if (!client_set) {
+            return;
+        }
+
         element = $("tr[fieldname=Contact] td[arnum=" + arnum + "] input")[0]
         filter_combogrid(element, "getParentUID", uid)
         // If client only has one contact then Auto-complete first Contact field.
@@ -362,7 +374,7 @@ function AnalysisRequestAddByCol() {
         element = $("tr[fieldname=Specification] td[arnum=" + arnum + "] input")[0]
         filter_combogrid(element, "getClientUID", uids)
         element = $("tr[fieldname=Sample] td[arnum=" + arnum + "] input")[0]
-        filter_combogrid(element, "getClientUID", uids);
+        filter_combogrid(element, "getClientUID", [uid,]);
     }
     /**
     * If client only has one contact, then Auto-complete the Contact field.
@@ -1447,7 +1459,9 @@ function AnalysisRequestAddByCol() {
         $("tr[fieldname='Sample'] td[arnum] input[type='text']")
           .live('selected copy', function (event, item) {
                     var arnum = get_arnum(this)
-                    sample_set(arnum)
+                    if ($(this).val()) {
+                        sample_set(arnum)
+                    }
                 })
           .each(function (i, e) {
                     if ($(e).val()) {

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -361,6 +361,8 @@ function AnalysisRequestAddByCol() {
         uids = [uid, $("#bika_setup").attr("bika_analysisspecs_uid")]
         element = $("tr[fieldname=Specification] td[arnum=" + arnum + "] input")[0]
         filter_combogrid(element, "getClientUID", uids)
+        element = $("tr[fieldname=Sample] td[arnum=" + arnum + "] input")[0]
+        filter_combogrid(element, "getClientUID", uids);
     }
     /**
     * If client only has one contact, then Auto-complete the Contact field.

--- a/bika/lims/content/sample.py
+++ b/bika/lims/content/sample.py
@@ -853,6 +853,12 @@ class Sample(BaseFolder, HistoryAwareMixin):
             prep_workflows.append([workflow_id, workflow.title])
         return DisplayList(prep_workflows)
 
+    def getSamplePartitions(self):
+        """Returns the Sample Partitions associated to this Sample
+        """
+        partitions = self.objectValues('SamplePartition')
+        return partitions
+
     @deprecated('[1705] Use events.after_no_sampling_workflow from '
                 'bika.lims.workflow.sample')
     @security.public

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -108,6 +108,7 @@ def create_analysisrequest(client, request, values, analyses=None,
                 analyses
             )
 
+    import pdb;pdb.set_trace()
     # At this point, we have a fully created AR, with a Sample, Partitions and
     # Analyses, but the state of all them is the initial ("sample_registered").
     # We can now transition the whole thing (instead of doing it manually for

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -93,10 +93,22 @@ def create_analysisrequest(client, request, values, analyses=None,
     # Create sample partitions
     if not partitions:
         partitions = [{'services': service_uids}]
+
+    part_num = 0
+    if secondary:
+        # Always create new partitions if is a Secondary AR, cause it does
+        # not make sense to reuse the partitions used in a previous AR!
+        sparts = sample.getSamplePartitions()
+        prefix = sample.getId() + "-P"
+        for spart in sparts:
+            spartnum = int(spart.getId().split(prefix)[1])
+            if spartnum > part_num:
+                part_num = spartnum
+
     for n, partition in enumerate(partitions):
         # Calculate partition id
         partition_prefix = sample.getId() + "-P"
-        partition_id = '%s%s' % (partition_prefix, n + 1)
+        partition_id = '%s%s' % (partition_prefix, part_num + 1)
         partition['part_id'] = partition_id
         # Point to or create sample partition
         if partition_id in sample.objectIds():
@@ -107,8 +119,8 @@ def create_analysisrequest(client, request, values, analyses=None,
                 partition,
                 analyses
             )
+        part_num += 1
 
-    import pdb;pdb.set_trace()
     # At this point, we have a fully created AR, with a Sample, Partitions and
     # Analyses, but the state of all them is the initial ("sample_registered").
     # We can now transition the whole thing (instead of doing it manually for
@@ -128,7 +140,11 @@ def create_analysisrequest(client, request, values, analyses=None,
         # children) to fit with the Sample Partition's current state
         sampleactions = getReviewHistoryActionsList(sample)
         doActionsFor(ar, sampleactions)
-
+        # We need to transition the partition manually
+        # Transition pre-preserved partitions
+        for partition in partitions:
+            part = partition['object']
+            doActionsFor(part, sampleactions)
     else:
         # If Preservation is required for some partitions, and the SamplingWorkflow
         # is disabled, we need to transition to to_be_preserved manually.
@@ -148,18 +164,16 @@ def create_analysisrequest(client, request, values, analyses=None,
                 doActionFor(p, 'sample_due')
             doActionFor(sample, lowest_state)
 
-        # Transition pre-preserved partitions
-        for p in partitions:
-            if 'prepreserved' in p and p['prepreserved']:
-                part = p['object']
-                state = workflow.getInfoFor(part, 'review_state')
-                if state == 'to_be_preserved':
-                    doActionFor(part, 'preserve')
+    # Transition pre-preserved partitions
+    for p in partitions:
+        if 'prepreserved' in p and p['prepreserved']:
+            part = p['object']
+            doActionFor(part, 'preserve')
 
-        # Once the ar is fully created, check if there are rejection reasons
-        reject_field = values.get('RejectionReasons', '')
-        if reject_field and reject_field.get('checkbox', False):
-            doActionFor(ar, 'reject')
+    # Once the ar is fully created, check if there are rejection reasons
+    reject_field = values.get('RejectionReasons', '')
+    if reject_field and reject_field.get('checkbox', False):
+        doActionFor(ar, 'reject')
 
     return ar
 


### PR DESCRIPTION
**Requires previous acceptance** of [PR#60 Status inconsistences in Analyses in secondary Analysis Requests](https://github.com/naralabs/bika.lims/pull/214)

In AR Add form, all Samples are (searched) displayed in "Sample" widget field, regardless of the current Client. The widget should search and display only those samples that belong to the same client.

With this Pull Request, the javascript for the AR Add form takes into account the current Client and applies a filter by client UID to the Sample's combo field. If the Analysis Request is being created outside a Client, the js automatically disable all the fields that are client-related ('Contact', 'CCContact', 'InvoiceContact', 'SamplePoint', 'Template', 'Profiles', 'Specification' and 'Sample') until a valid Client is selected. Once selected, the fields above are enabled and a filter by client UID is applied to all them, so the result of searches will be limited to the selected Client.

Some improvements to make ReferenceWidget searches have been applied too. Also, if no brains are found by the ReferenceWidget search machinery, returns empty by default (until now, the criteria was that if no items found, returned all them without filtering by searchterm).