### PR TITLE
Render barcodes as bitmap images by default

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -174,6 +174,14 @@
                 color: red;
                 padding: 5px;
             }
+            .barcode-hri {
+                clear:both;
+                width: 100%;
+                background-color: #FFFFFF;
+                color: #000000;
+                text-align: center;
+                font-size: 10px;
+            }
         </style>
         <style id='report-style' tal:content='structure python:view.getReportStyle()'></style>
         <style id='layout-style'></style>

--- a/bika/lims/browser/js/bika.lims.utils.barcode.js
+++ b/bika/lims/browser/js/bika.lims.utils.barcode.js
@@ -28,7 +28,8 @@ function BarcodeUtils() {
             $(this).barcode(id, code,
                             {'barHeight': parseInt(barHeight),
                              'addQuietZone': (addQuietZone == 'true'),
-                             'showHRI': (showHRI == 'true') });
+                             'showHRI': (showHRI == 'true'),
+                             'output': "bmp", });
         });
     }
 }

--- a/bika/lims/browser/js/bika.lims.utils.barcode.js
+++ b/bika/lims/browser/js/bika.lims.utils.barcode.js
@@ -30,6 +30,15 @@ function BarcodeUtils() {
                              'addQuietZone': (addQuietZone == 'true'),
                              'showHRI': (showHRI == 'true'),
                              'output': "bmp", });
+
+            if (showHRI == 'true') {
+                // When output is set to "bmp", the showHRI parameter (that
+                // prints the ID below the barcode) is dissmissed by barcode.js
+                // so we need to add it manually
+                $(this).find('.barcode-hri').remove();
+                var barcode_hri = '<div class="barcode-hri">'+id+'</div>';
+                $(this).append(barcode_hri);
+            }
         });
     }
 }

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -88,6 +88,14 @@
             border-bottom: 1px dotted #cdcdcd;
             box-shadow: 1px 2px 5px #cdcdcd;
         }
+        .barcode-hri {
+            clear:both;
+            width: 100%;
+            background-color: #FFFFFF;
+            color: #000000;
+            text-align: center;
+            font-size: 10px;
+        }
 
         @media print {
             html, body {

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -103,6 +103,20 @@
               box-shadow:none;
               border-bottom:none;
             }
+            .page-break, .page-break-after, .page-break-before {
+                display: block !important;
+                border:none !important;
+                padding:0 !important;
+                margin:0 !important;
+                background-color:transparent !important;
+            }
+            div.page-break,
+            div.page-break-after {
+                page-break-after: always;
+            }
+            div.page-break-before {
+                page-break-before: always;
+            }
             #sticker-rule {
                 display:none !important;
             }

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -213,7 +213,6 @@
             </div>
         </div>
 
-        <!-- Container where all the stickers are embedded. -->
         <div id="stickers-wrapper">
             <style id='stickers-style' type="text/css" tal:content="structure python:view.getSelectedTemplateCSS()"></style>
             <div id="sticker-rule">


### PR DESCRIPTION
At the moment, barcodes are generated with styled html by default, but it usually causes problems on printing and during the generation of pdfs (related #146). To overcome these problems, this PR makes barcodes to always be rendered as bitmap images (bmp) instead.

The javascript for creating barcodes ([barcode-coder](http://barcode-coder.com/en/)) can receive `showHRI` as an input parameter. If `showHRI` is set to true, barcode-coder displays text (HRI : Human readable Interpretation) below the barcode, but only if the `output` param is set to `css` by default. When `output` param is set to `bmp` (bitmap image), `showHRI` has no effect and the text is not rendered. Since the value for `output` param is set to `bmp` by default now, there is the need to keep the previous functionality. With this pull request, the text (code) below the barcode is automatically generated by `bika.lims.utils.barcode.js` when `showHRI=='true'`. 

