### PR TITLE
Not all departments are displayed when creating a new LabContact

### DIFF
--- a/bika/lims/content/labcontact.py
+++ b/bika/lims/content/labcontact.py
@@ -155,7 +155,7 @@ class LabContact(Contact):
         """
         Returns a vocabulary object with the available departments.
         """
-        bsc = getToolByName(self, 'portal_catalog')
+        bsc = getToolByName(self, 'bika_setup_catalog')
         items = [(o.UID, o.Title) for o in
                                bsc(portal_type='Department',
                                    inactive_state = 'active')]


### PR DESCRIPTION
Using portal_catalog wasn't returning all departments.