### PR TITLE
NDEV-69 Filters by Service, Category and Client do not work when adding Analyses into a Worksheet

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -43,7 +43,7 @@ function WorksheetAddAnalysesView() {
 
         // search form - selecting a category fills up the service selector
         $('[name="list_getCategoryTitle"]').live("change", function(){
-            val = $('[name="list_getCategoryTitle"]').val();
+            val = $('[name="list_getCategoryTitle"]').find(":selected").val();
             if(val == 'any'){
                 $('[name="list_Title"]').empty();
                 $('[name="list_Title"]').append("<option value='any'>"+_('Any')+"</option>");
@@ -53,7 +53,7 @@ function WorksheetAddAnalysesView() {
                 url: window.location.href.split("?")[0].replace("/add_analyses","") + "/getServices",
                 type: 'POST',
                 data: {'_authenticator': $('input[name="_authenticator"]').val(),
-                       'getCategoryTitle': val},
+                       'getCategoryUID': val},
                 dataType: "json",
                 success: function(data, textStatus, $XHR){
                     current_service_selection = $('[name="list_Title"]').val();
@@ -65,7 +65,9 @@ function WorksheetAddAnalysesView() {
                         } else {
                             selected = '';
                         }
-                        $('[name="list_Title"]').append("<option "+selected+"value='"+data[i]+"'>"+data[i]+"</option>");
+                        $('[name="list_Title"]').append(
+                            "<option "+selected+"value='"+data[i][0]+
+                            "'>"+data[i][1]+"</option>");
                     }
                 }
             });

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -104,6 +104,8 @@ function WorksheetAddAnalysesView() {
                 replaceTarget: true,
                 data: form.formToArray(),
                 success: function () {
+                    // Reload bika listing transitions watchers
+                    window.bika.lims.BikaListingTableView.load();
                 }
             }
             var url = window.location.href.split("?")[0].split("/add_analyses")[0];

--- a/bika/lims/browser/worksheet/ajax.py
+++ b/bika/lims/browser/worksheet/ajax.py
@@ -26,11 +26,13 @@ class GetServices():
     def __call__(self):
         plone.protect.CheckAuthenticator(self.request)
         bsc = getToolByName(self.context, 'bika_setup_catalog')
-        return json.dumps([c.Title for c in
-                bsc(portal_type = 'AnalysisService',
-                   getCategoryTitle = self.request.get('getCategoryTitle', ''),
-                   inactive_state = 'active',
-                   sort_on = 'sortable_title')])
+        brains = bsc(
+            portal_type='AnalysisService',
+            getCategoryUID=self.request.get('getCategoryUID', ''),
+            inactive_state='active',
+            sort_on='sortable_title')
+        voc = [[brain.UID, brain.Title] for brain in brains]
+        return json.dumps(voc)
 
 
 class AttachAnalyses():

--- a/bika/lims/browser/worksheet/templates/add_analyses.pt
+++ b/bika/lims/browser/worksheet/templates/add_analyses.pt
@@ -43,14 +43,15 @@
 				<input type="hidden" name="submitted" value="1"/>
 				<input tal:replace="structure context/@@authenticator/authenticator"/>
 				<label for="getWorksheetTemplate" i18n:translate="">Select template</label>
-				<select id="ProfileSelector" name="getWorksheetTemplate">
+				<select id="ProfileSelector" name="getWorksheetTemplate"
+					tal:define="olist view/getWorksheetTemplates">
 					<option value=""></option>
-					<tal:profile repeat="profile view/getWorksheetTemplates">
+					<tal:profile repeat="profile olist">
 						<option
 							tal:attributes="
-								value python:profile[0];
+								value python:profile;
 								selected python: view.request.get('WorksheetTemplate', '') == profile[0] and 'selected' or ''"
-							tal:content="python:profile[1]"/>
+							tal:content="python:olist.getValue(profile)"/>
 					</tal:profile>
 				</select>&nbsp;
 				<input type="submit"
@@ -66,14 +67,15 @@
 				i18n:translate="">Category</label>
 			<select id="CategorySelector"
 					tal:attributes="name string:${form_id}_getCategoryTitle"
+					tal:define="olist view/getCategories"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
-				<tal:options repeat="category view/getCategories">
+				<tal:options repeat="category olist">
 					<option
 						tal:attributes="
 							value python:category;
 							selected python: view.request.form.get(form_id+'_getCategoryTitle', '') == category and 'selected' or ''"
-						tal:content="python:category"/>
+						tal:content="python:olist.getValue(category)"/>
 				</tal:options>
 			</select>
 
@@ -81,14 +83,15 @@
 				i18n:translate="">Service</label>
 			<select id="ServiceSelector"
 					tal:attributes="name string:${form_id}_Title"
+					tal:define="olist view/getServices"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
-				<tal:options repeat="service view/getServices">
+				<tal:options repeat="service olist">
 					<option
 						tal:attributes="
 							value python:service;
 							selected python: view.request.form.get(form_id+'_Title', '') == service and 'selected' or ''"
-						tal:content="python:service"/>
+						tal:content="python:olist.getValue(service)"/>
 				</tal:options>
 			</select>
 
@@ -96,14 +99,15 @@
 				i18n:translate="">Client</label>
 			<select id="ClientSelector"
 					tal:attributes="name string:${form_id}_getClientTitle"
+					tal:define="olist view/getClients"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
-				<tal:options repeat="client view/getClients">
+				<tal:options repeat="client olist">
 					<option
 						tal:attributes="
 							value python:client;
 							selected python: view.request.form.get(form_id+'_getClientTitle', '') == client and 'selected' or ''"
-						tal:content="python:client"/>
+						tal:content="python:olist.getValue(client)"/>
 				</tal:options>
 			</select>&nbsp;
 			<a tal:attributes="href view/view_url" i18n:translate=""

--- a/bika/lims/browser/worksheet/templates/add_analyses.pt
+++ b/bika/lims/browser/worksheet/templates/add_analyses.pt
@@ -44,14 +44,14 @@
 				<input tal:replace="structure context/@@authenticator/authenticator"/>
 				<label for="getWorksheetTemplate" i18n:translate="">Select template</label>
 				<select id="ProfileSelector" name="getWorksheetTemplate"
-					tal:define="olist view/getWorksheetTemplates">
+					tal:define="ws_templates_list view/getWorksheetTemplates">
 					<option value=""></option>
-					<tal:profile repeat="profile olist">
+					<tal:profile repeat="profile ws_templates_list">
 						<option
 							tal:attributes="
 								value python:profile;
 								selected python: view.request.get('WorksheetTemplate', '') == profile[0] and 'selected' or ''"
-							tal:content="python:olist.getValue(profile)"/>
+							tal:content="python:ws_templates_list.getValue(profile)"/>
 					</tal:profile>
 				</select>&nbsp;
 				<input type="submit"
@@ -67,15 +67,15 @@
 				i18n:translate="">Category</label>
 			<select id="CategorySelector"
 					tal:attributes="name string:${form_id}_getCategoryTitle"
-					tal:define="olist view/getCategories"
+					tal:define="categories_list view/getCategories"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
-				<tal:options repeat="category olist">
+				<tal:options repeat="category categories_list">
 					<option
 						tal:attributes="
 							value python:category;
 							selected python: view.request.form.get(form_id+'_getCategoryTitle', '') == category and 'selected' or ''"
-						tal:content="python:olist.getValue(category)"/>
+						tal:content="python:categories_list.getValue(category)"/>
 				</tal:options>
 			</select>
 
@@ -83,15 +83,15 @@
 				i18n:translate="">Service</label>
 			<select id="ServiceSelector"
 					tal:attributes="name string:${form_id}_Title"
-					tal:define="olist view/getServices"
+					tal:define="services_list view/getServices"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
-				<tal:options repeat="service olist">
+				<tal:options repeat="service services_list">
 					<option
 						tal:attributes="
 							value python:service;
 							selected python: view.request.form.get(form_id+'_Title', '') == service and 'selected' or ''"
-						tal:content="python:olist.getValue(service)"/>
+						tal:content="python:services_list.getValue(service)"/>
 				</tal:options>
 			</select>
 
@@ -99,15 +99,15 @@
 				i18n:translate="">Client</label>
 			<select id="ClientSelector"
 					tal:attributes="name string:${form_id}_getClientTitle"
-					tal:define="olist view/getClients"
+					tal:define="clients_list view/getClients"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
-				<tal:options repeat="client olist">
+				<tal:options repeat="client clients_list">
 					<option
 						tal:attributes="
 							value python:client;
 							selected python: view.request.form.get(form_id+'_getClientTitle', '') == client and 'selected' or ''"
-						tal:content="python:olist.getValue(client)"/>
+						tal:content="python:clients_list.getValue(client)"/>
 				</tal:options>
 			</select>&nbsp;
 			<a tal:attributes="href view/view_url" i18n:translate=""

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -21,6 +21,7 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.browser.worksheet.tools import checkUserManage
 from bika.lims.browser.worksheet.tools import showRejectionMessage
 from bika.lims.utils import t
+from bika.lims.vocabularies import CatalogVocabulary
 
 
 class AddAnalysesView(BikaListingView):
@@ -102,9 +103,6 @@ class AddAnalysesView(BikaListingView):
 
         showRejectionMessage(self.context)
 
-        translate = self.context.translate
-
-        form_id = self.form_id
         form = self.request.form
         rc = getToolByName(self.context, REFERENCE_CATALOG)
         if 'submitted' in form:
@@ -197,32 +195,33 @@ class AddAnalysesView(BikaListingView):
         return item
 
     def getServices(self):
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
-        return [c.Title for c in
-                bsc(portal_type = 'AnalysisService',
-                   getCategoryUID = self.request.get('list_getCategoryUID', ''),
-                   inactive_state = 'active',
-                   sort_on = 'sortable_title')]
+        vocabulary = CatalogVocabulary(self)
+        vocabulary.catalog = 'bika_setup_catalog'
+        categoryUID = self.request.get('list_getCategoryUID', '')
+        if categoryUID:
+            return vocabulary(
+                portal_type='AnalysisService',
+                getCategoryUID=categoryUID,
+                sort_on='sortable_title'
+            )
+        return vocabulary(
+            portal_type='AnalysisService',
+            sort_on='sortable_title'
+        )
 
     def getClients(self):
-        pc = getToolByName(self.context, 'portal_catalog')
-        return [c.Title for c in
-                pc(portal_type = 'Client',
-                   inactive_state = 'active',
-                   sort_on = 'sortable_title')]
+        vocabulary = CatalogVocabulary(self)
+        return vocabulary(portal_type='Client', sort_on='sortable_title')
 
     def getCategories(self):
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
-        return [c.Title for c in
-                bsc(portal_type = 'AnalysisCategory',
-                   inactive_state = 'active',
-                   sort_on = 'sortable_title')]
+        vocabulary = CatalogVocabulary(self)
+        vocabulary.catalog = 'bika_setup_catalog'
+        return vocabulary(
+            portal_type='AnalysisCategory',  sort_on='sortable_title')
 
     def getWorksheetTemplates(self):
         """ Return WS Templates """
-        profiles = []
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
-        return [(c.UID, c.Title) for c in
-                bsc(portal_type = 'WorksheetTemplate',
-                   inactive_state = 'active',
-                   sort_on = 'sortable_title')]
+        vocabulary = CatalogVocabulary(self)
+        vocabulary.catalog = 'bika_setup_catalog'
+        return vocabulary(
+            portal_type='WorksheetTemplate', sort_on='sortable_title')

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -121,6 +121,25 @@ class AddAnalysesView(BikaListingView):
                         _("No analyses were added to this worksheet."))
                     self.request.RESPONSE.redirect(self.context.absolute_url() +
                                                    "/add_analyses")
+            elif (
+                'list_getCategoryTitle' in form or
+                'list_Title' in form or
+                'list_getClientTitle' in form
+                    ):
+                # Apply filter elements
+                # Note that the name of those fields is '..Title', but we
+                # are getting their UID.
+                category = form.get('list_getCategoryTitle', '')
+                if category:
+                    self.contentFilter['getCategoryUID'] = category
+
+                service = form.get('list_Title', '')
+                if service:
+                    self.contentFilter['getServiceUID'] = service
+
+                client = form.get('list_getClientTitle', '')
+                if client:
+                    self.contentFilter['getClientUID'] = client
 
         self._process_request()
 

--- a/bika/lims/vocabularies/__init__.py
+++ b/bika/lims/vocabularies/__init__.py
@@ -47,8 +47,9 @@ class CatalogVocabulary(object):
         site = getSite()
         request = aq_get(site, 'REQUEST', None)
         catalog = getToolByName(site, self.catalog)
+        allow_blank = False
         if 'allow_blank' in kwargs:
-            allow_blank = True
+            allow_blank = kwargs.get('allow_blank')
             del (kwargs['allow_blank'])
 
         self.contentFilter.update(**kwargs)


### PR DESCRIPTION
When the user creates a Worksheet, the Add Analyses view is displayed. In this view, there is a bar that allows the user to filter the analyses to be included in the worksheet by several criteria: Analysis Service, Category and Client. Seems that once the Search button is pressed, the filter has no effect.

This issue has been resolved by getting the filter parameters and reloading the bikalisting javascript.

It also uses the vocabulary creator in order to fill the filter options.