### PR TITLE
NDEV-75 Export to CSV/XML in lists does not work in some cases

### DIFF
--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -803,7 +803,8 @@ function BikaListingTableView() {
                 output = data.join('\r\n');
                 urischema = 'data:application/csv;base64;charset=UTF-8,';
             }
-            var uri = urischema + btoa(output);
+            var b64 = window.btoa(unescape(encodeURIComponent(output)));
+            var uri = urischema + b64;
             $(this).attr('href', uri);
         });
 


### PR DESCRIPTION
When the list to be exported contains items with special characters, the exporter does not work as expected and returns an HTML file instead of either a CSV or XML.

The javascript responsible of this functionality throws the following error when trying the conversion to base64:

    InvalidCharacterError: String contains an invalid character
