### PR TITLE
NDEV-70 Action buttons are not translated

### DIFF
--- a/bika/lims/browser/jsi18n.py
+++ b/bika/lims/browser/jsi18n.py
@@ -1,0 +1,36 @@
+from plone.memoize import ram
+from zope.component import queryUtility
+from zope.i18n.interfaces import ITranslationDomain
+from jarn.jsi18n.view import i18njs as BaseView
+from jarn.jsi18n.view import _cache_key
+
+
+class i18njs(BaseView):
+
+    @ram.cache(_cache_key)
+    def _gettext_catalog(self, domain, language):
+        """
+        Overrides jarn.jsi18n.view.jsi18n
+        See:
+            https://github.com/collective/jarn.jsi18n/issues/1
+            https://github.com/collective/jarn.jsi18n/pull/2
+
+        :param domain: translation domain
+        :param language: iso code for language
+        :return: dict, with the translations for the domain and language
+        """
+        td = queryUtility(ITranslationDomain, domain)
+        if td is None or language not in td._catalogs:
+            return
+
+        _catalog = {}
+        for mo_path in td._catalogs[language]:
+            catalog = td._data[mo_path]._catalog
+            if catalog is None:
+                td._data[mo_path].reload()
+                catalog = td._data[mo_path]._catalog
+            catalog = catalog._catalog
+            for key, val in catalog.iteritems():
+                if val:
+                    _catalog[key] = val
+        return _catalog

--- a/bika/lims/browser/overrides.zcml
+++ b/bika/lims/browser/overrides.zcml
@@ -47,4 +47,19 @@
         template="templates/plone-overview.pt"
     />
 
+    <!---
+    jarn.jsi18n uses the first catalog it comes across for a particular domain
+    and language. Bika LIMS has additional plone.mo files that should
+    extend/override the translation strings set by default from Plone and other
+    add-ons:
+    https://github.com/collective/jarn.jsi18n/blob/0f5d8d6e9cf7925e63f97f35245492fcbcd5a789/jarn/jsi18n/view.py#L21
+    See https://github.com/collective/jarn.jsi18n/issues/1
+    -->
+    <browser:view
+        for="*"
+        name="jsi18n"
+        class=".jsi18n.i18njs"
+        permission="zope2.View"
+    />
+
 </configure>


### PR DESCRIPTION
`jarn.jsi18n` uses the first matched catalog instead of merging the translation resources available for the same domain and language. More info: [ jarn.jsi18n uses the first matched catalog](https://github.com/collective/jarn.jsi18n/issues/1)

This causes that action buttons, as well as other translations retrieved javascript do not render properly in some cases. With this Pull Request, the function from jarn.jsi18n has been overriden, so it takes into account now all translation resources from a given domain and language.

A Pull Request to the official repos has been created too: https://github.com/collective/jarn.jsi18n/pull/2

Note `jarn.jsi18n` stores the catalog for 24 hours by default. To x-check this PR, you can set the time-to-live by calling jarn.i18n.setTTL(millis) passing in milliseconds for how long the local storage cache should remain valid. Note that if local storage is supported, and the cache has not expired, the browser will NOT reload a catalog.