### PR TITLE
Malformed messages and/or html that makes i18ndude to fail

### DIFF
--- a/bika/lims/browser/department/labcontacts.py
+++ b/bika/lims/browser/department/labcontacts.py
@@ -21,10 +21,8 @@ class LabContactsView(LabContactsView):
         super(LabContactsView, self).__init__(context, request)
         self.show_select_all_checkbox = False
         self.description = self.context.translate(_(
-            """
-            By selecting/unselecting the checboxes, the user will be able to
-            "Lab Contacts" to the department.
-            """))
+            'By selecting/unselecting the checboxes, the user will be able ' \
+            'to assign "Lab Contacts" to the department.'))
         self.context_actions = {}
         self.contentFilter = {
             'portal_type': 'LabContact',

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -47,7 +47,6 @@
                         <li tal:define="dep_name python:dep.Title if user_name=='admin' else dep.Title();
                                         dep_uid python: dep.UID if user_name=='admin' else dep.UID()">
                             <input type="checkbox"
-                            <input type="checkbox"
                                 tal:attributes="
                                     value python: dep_uid;
                                     name python: 'chb_deps_'+ dep_name;

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -43,15 +43,18 @@
                        <label tal:condition= "python: user_name=='admin'">Select All Departments<br><br></label>
 
                 <tal:option repeat="dep deps" tal:condition="python: len(deps)>1">
-                <input type="checkbox"
-                    tal:define="dep_name python:dep.Title if user_name=='admin' else dep.Title();
-                                dep_uid python: dep.UID if user_name=='admin' else dep.UID()"
-                    tal:content="python: dep_name"
-                    tal:attributes="
-                        value python: dep_uid;
-                        name python: 'chb_deps_'+ dep_name;
-                        checked python: 'true' if dep_disabled=='true' else 'true' if any(dep_uid in cd for cd in deps_from_cookie) else 'true' if first_dep==dep_uid else ''"
-                    i18n:translate=""/><br>
+                    <ul>
+                        <li tal:define="dep_name python:dep.Title if user_name=='admin' else dep.Title();
+                                        dep_uid python: dep.UID if user_name=='admin' else dep.UID()">
+                            <input type="checkbox"
+                            <input type="checkbox"
+                                tal:attributes="
+                                    value python: dep_uid;
+                                    name python: 'chb_deps_'+ dep_name;
+                                    checked python: 'true' if dep_disabled=='true' else 'true' if any(dep_uid in cd for cd in deps_from_cookie) else 'true' if first_dep==dep_uid else ''"/>
+                            <span tal:content="python: dep_name"></span>
+                        </li>
+                    </ul>
                 </tal:option>
 
                 <!-- Only a label with the department if one department only -->


### PR DESCRIPTION
i18ndude throws an exception when generating .mo files because of a malformed message and bad use of input html tag in portlet_department_filter.pt. Regarding the later, this PR changes the structure of the portlet and generates a non-numbered list (li) instead of a list of items separated with a breakline (br).