### PR TITLE
Display Priority in Analyses Add View from Worksheet and allow to sort

### DIFF
--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -14,6 +14,7 @@ from Products.CMFPlone.i18nl10n import ulocalized_time
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.config import PRIORITIES
 from bika.lims import bikaMessageFactory as _
 from bika.lims import EditResults, EditWorksheet, ManageWorksheets
 from bika.lims import PMF, logger
@@ -49,6 +50,10 @@ class AddAnalysesView(BikaListingView):
         self.pagesize = 50
 
         self.columns = {
+            'Priority': {
+                'title': '',
+                'sortable': True,
+                'index': 'getPrioritySortkey' },
             'Client': {
                 'title': _('Client'),
                 'attr': 'getClientTitle',
@@ -82,7 +87,8 @@ class AddAnalysesView(BikaListingView):
              'title': _('All'),
              'contentFilter': {},
              'transitions': [{'id':'assign'}, ],
-             'columns':['Client',
+             'columns':['Priority',
+                        'Client',
                         'getClientOrderNumber',
                         'getRequestID',
                         'CategoryTitle',
@@ -211,6 +217,16 @@ class AddAnalysesView(BikaListingView):
                  t(_("Late Analysis")))
         if self.hideclientlink:
             del item['replace']['Client']
+        # Add Priority column
+        priority_sort_key = obj.getPrioritySortkey
+        if not priority_sort_key:
+            # Default priority is Medium = 3.
+            # The format of PrioritySortKey is <priority>.<created>
+            priority_sort_key = '3.%s' % obj.created.ISO8601()
+        priority = priority_sort_key.split('.')[0]
+        priority_text = PRIORITIES.getValue(priority)
+        priority_div = '<div class="priority-ico priority-%s"><span class="notext">%s</span><div>'
+        item['replace']['Priority'] = priority_div % (priority, priority_text)
         return item
 
     def getServices(self):

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -414,6 +414,17 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         return dependencies
 
     @security.public
+    def getPrioritySortkey(self):
+        """
+        Returns the key that will be used to sort the current Analysis
+        Delegates to getPrioritySortKey function from the AnalysisRequest
+        :return: string used for sorting
+        """
+        analysis_request = self.getRequest()
+        if analysis_request:
+            return analysis_request.getPrioritySortkey()
+
+    @security.public
     def setReflexAnalysisOf(self, analysis):
         """Sets the analysis that has been reflexed in order to create this
         one, but if the analysis is the same as self, do nothing.

--- a/bika/lims/upgrade/v3_2_0_1708.py
+++ b/bika/lims/upgrade/v3_2_0_1708.py
@@ -44,6 +44,9 @@ def upgrade(tool):
     # Add missing Priority Index and Column to AR Catalog
     ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING,
                          'getPrioritySortkey', 'FieldIndex')
+    ut.addIndexAndColumn(CATALOG_ANALYSIS_LISTING,
+                         'getPrioritySortkey', 'FieldIndex')
+
     ut.refreshCatalogs()
 
     logger.info("{0} upgraded to version {1}".format(product, version))


### PR DESCRIPTION
Enhances [
NMRL-171 Priority not showing on Analysis Request listing](https://github.com/naralabs/bika.lims/pull/230).

With this Pull Request, a Priority column is displayed in the Add Analyses view from Worksheet. The priority associated to each analysis corresponds to the priority assigned to the Analysis Request to which belongs. The list can also be sorted by the Priority column, following the same criteria as described for Analysis Requests lists in #230 

**Screenshots**

Analyses Add View (sorted by default):

![priority5](https://user-images.githubusercontent.com/832627/29775463-852e9802-8c05-11e7-8ae8-1939274e268a.png)

Analyses Add View sorted by Priority ASC

![priority6](https://user-images.githubusercontent.com/832627/29775482-9602455c-8c05-11e7-97a7-178a5eb5e6c8.png)
