### PR TITLE
Background color change on mouse over for fields table from AR Add view

### DIFF
--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1327,6 +1327,7 @@ div#semioverlay div.semioverlay-buttons input:hover {
         .ArchetypesPrioritySelectionWidget select[value="5"],
         .ArchetypesPrioritySelectionWidget select option[value="5"] {
             background-image: url(&dtml-portal_url;/++resource++bika.lims.images/lowest.svg); }
+
 .priority-ico {
     background-position: left top;
     background-repeat: no-repeat;
@@ -1349,5 +1350,17 @@ div#semioverlay div.semioverlay-buttons input:hover {
 
     .priority-ico.priority-5 {
         background-image: url(&dtml-portal_url;/++resource++bika.lims.images/lowest.svg); }
+
+/* Analysis Request fields table from Add form */
+table.analysisrequest.add {}
+    table.analysisrequest.add tr:hover td,
+    table.analysisrequest.add tr:hover th,
+    table.analysisrequest.add tr:hover td span,
+    table.analysisrequest.add tr:hover th span {
+        background-color: #fff9ee !important; }
+
+    table.analysisrequest.add tr:hover th,
+    table.analysisrequest.add tr:hover th span {
+        border-right:none; }
 
 </dtml-with>


### PR DESCRIPTION
As per [NDEV-74 Highlight rows in bikalisting on mouse over](https://github.com/naralabs/bika.lims/pull/229), the background color of rows in list changes on mouse over, but the AR Add form uses its own specific template to generate the table. The fields from the Analysis Request are rendered in this table so each column represents an Analysis Request. Quite often (when the number of ARs is >=4) is difficult for the user to see which specific field is under edition.

With this Pull Request, the rows from the table that renders the fields of the Analysis Request in the Add form are highlighted on mouse over.

**Screenshots**

Analysis Request Add view with highlighting:

![highlight](https://user-images.githubusercontent.com/832627/29779780-e3c50708-8c13-11e7-847e-fe5dacda4e98.png)
