### PR TITLE
bug- Jsi18n adapter conflict

### DIFF
--- a/bika/lims/browser/jsi18n.py
+++ b/bika/lims/browser/jsi18n.py
@@ -31,6 +31,6 @@ class i18njs(BaseView):
                 catalog = td._data[mo_path]._catalog
             catalog = catalog._catalog
             for key, val in catalog.iteritems():
-                if val:
+                if key and val:
                     _catalog[key] = val
         return _catalog

--- a/bika/lims/browser/overrides.zcml
+++ b/bika/lims/browser/overrides.zcml
@@ -28,6 +28,14 @@
                 permission="zope.Public"
                 template="templates/plone-overview.pt"
             />
+
+            <browser:view
+                 for="*"
+                 name="jsi18n"
+                 class="jarn.jsi18n.view.i18njs"
+                 permission="zope2.View"
+             />
+
         </unconfigure>
     </configure>
 


### PR DESCRIPTION
Since we are overriding 'jsi18n' adapter, we had to unconfigure the existing one from Plone itself.
Also, to avoid returning long, meaningless values for empty strings from translation, a validator was added.  