### PR TITLE
Progress bar column in Analysis Requests list and AnalysesNum revisited

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -77,6 +77,9 @@ class AnalysisRequestsView(BikaListingView):
                 'title': '',
                 'index': 'getPrioritySortkey',
                 'sortable': True,},
+            'Progress': {
+                'title': 'Progress',
+                'toggle': True},
             'getRequestID': {
                 'title': _('Request ID'),
                 'attr': 'getId',
@@ -222,6 +225,7 @@ class AnalysisRequestsView(BikaListingView):
                              {'id': 'reinstate'}],
              'custom_actions': [],
              'columns': ['Priority',
+                         'Progress',
                         'getRequestID',
                         'getSample',
                         'BatchID',
@@ -830,10 +834,30 @@ class AnalysisRequestsView(BikaListingView):
 
         analysesnum = obj.getAnalysesNum
         if analysesnum:
-            item['getAnalysesNum'] = \
-                str(analysesnum[0]) + '/' + str(analysesnum[1])
+            num_verified = str(analysesnum[0])
+            num_total = str(analysesnum[1])
+            item['getAnalysesNum'] = '{0}/{1}'.format(num_verified, num_total)
         else:
             item['getAnalysesNum'] = ''
+
+        # Progress
+        num_verified = 0
+        num_submitted = 0
+        if analysesnum and len(analysesnum) > 1:
+            num_verified = analysesnum[0]
+            num_total = analysesnum[1]
+            num_submitted = num_total - num_verified
+            if len(analysesnum) > 2:
+                num_wo_results = analysesnum[2]
+                num_submitted = num_total - num_verified - num_wo_results
+        num_steps_total = num_total * 2
+        num_steps = (num_verified * 2) + (num_submitted)
+        progress_perc = (num_steps * 100) / num_steps_total
+        progress = '<div class="progress-bar-container">' + \
+                   '<div class="progress-bar" style="width:{0}%"></div>' + \
+                   '<div class="progress-perc">{0}%</div></div>'
+        item['replace']['Progress'] = progress.format(progress_perc)
+
         item['BatchID'] = obj.getBatchID
         if obj.getBatchID:
             item['replace']['BatchID'] = "<a href='%s'>%s</a>" % \

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -843,6 +843,7 @@ class AnalysisRequestsView(BikaListingView):
         # Progress
         num_verified = 0
         num_submitted = 0
+        num_total = 0
         if analysesnum and len(analysesnum) > 1:
             num_verified = analysesnum[0]
             num_total = analysesnum[1]

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -54,7 +54,7 @@
 <tal:comment replace="nothing">***************
 Item select checkboxes.
 ********************************</tal:comment>
-<td style="width:24px;"
+<td style="width:20px;"
     tal:condition="view/bika_listing/show_select_column"
     tal:define="cl python:'class' in item and 'select_column' in item['class'] and
                 item['class']['select_column'] or '';"

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1350,4 +1350,21 @@ div#semioverlay div.semioverlay-buttons input:hover {
     .priority-ico.priority-5 {
         background-image: url(&dtml-portal_url;/++resource++bika.lims.images/lowest.svg); }
 
+.progress-bar-container {
+    background-color: #efefef;
+    border: 1px solid #c1c1c1;
+    border-radius: 3px;
+    height: 14px;
+    width: 50px;
+    margin-top:-2px;
+}
+    .progress-bar-container .progress-bar {
+        background-color: #a2d0ce;
+        height: inherit;
+    }
+    .progress-bar-container .progress-perc {
+        font-size: 0.85em;
+        margin-top: -15px;
+        width: inherit;
+        text-align:center; }
 </dtml-with>

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -2,6 +2,7 @@ from Products.CMFCore.utils import getToolByName
 from DateTime import DateTime
 
 from bika.lims import logger
+from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils.analysis import create_analysis
 from bika.lims.workflow import doActionFor
@@ -23,10 +24,7 @@ def after_submit(obj):
     ws = obj.getWorksheet()
     if ws:
         doActionFor(ws, 'submit')
-
-    request = obj.getRequest()
-    if request:
-        request.reindexObject()
+    _reindex_request(obj)
 
 
 def after_retract(obj):
@@ -74,9 +72,7 @@ def after_retract(obj):
     for dependent in dependents:
         doActionFor(dependent, 'retract')
 
-    request = obj.getRequest()
-    if request:
-        request.reindexObject()
+    _reindex_request(obj)
 
 
 def after_verify(obj):
@@ -109,10 +105,7 @@ def after_verify(obj):
     ws = obj.getWorksheet()
     if ws:
         doActionFor(ws, 'verify')
-
-    request = obj.getRequest()
-    if request:
-        request.reindexObject()
+    _reindex_request(obj)
 
 
 
@@ -127,9 +120,7 @@ def after_cancel(obj):
         skip(obj, "cancel", unskip=True)
         ws.removeAnalysis(obj)
     obj.reindexObject()
-    request = obj.getRequest()
-    if request:
-        request.reindexObject()
+    _reindex_request(obj)
 
 
 def after_reject(obj):
@@ -142,9 +133,8 @@ def after_reject(obj):
         ws = obj.getWorksheet()
         ws.removeAnalysis(obj)
     obj.reindexObject()
-    request = obj.getRequest()
-    if request:
-        request.reindexObject()
+    _reindex_request(obj)
+
 
 def after_attach(obj):
     if skip(obj, "attach"):
@@ -182,6 +172,11 @@ def after_attach(obj):
             if can_attach:
                 workflow.doActionFor(ws, "attach")
     obj.reindexObject()
-    ar = obj.getRequest()
-    if ar:
-        ar.reindexObject()
+    _reindex_request(obj)
+
+
+def _reindex_request(obj):
+    if IRoutineAnalysis.providedBy(obj):
+        request = obj.getRequest()
+        if request:
+            request.reindexObject()

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -24,6 +24,10 @@ def after_submit(obj):
     if ws:
         doActionFor(ws, 'submit')
 
+    request = obj.getRequest()
+    if request:
+        request.reindexObject()
+
 
 def after_retract(obj):
     """Function triggered after a 'retract' transition for the analysis passed
@@ -70,6 +74,10 @@ def after_retract(obj):
     for dependent in dependents:
         doActionFor(dependent, 'retract')
 
+    request = obj.getRequest()
+    if request:
+        request.reindexObject()
+
 
 def after_verify(obj):
     """
@@ -102,6 +110,11 @@ def after_verify(obj):
     if ws:
         doActionFor(ws, 'verify')
 
+    request = obj.getRequest()
+    if request:
+        request.reindexObject()
+
+
 
 def after_cancel(obj):
     if skip(obj, "cancel"):
@@ -114,6 +127,9 @@ def after_cancel(obj):
         skip(obj, "cancel", unskip=True)
         ws.removeAnalysis(obj)
     obj.reindexObject()
+    request = obj.getRequest()
+    if request:
+        request.reindexObject()
 
 
 def after_reject(obj):
@@ -126,7 +142,9 @@ def after_reject(obj):
         ws = obj.getWorksheet()
         ws.removeAnalysis(obj)
     obj.reindexObject()
-
+    request = obj.getRequest()
+    if request:
+        request.reindexObject()
 
 def after_attach(obj):
     if skip(obj, "attach"):
@@ -164,3 +182,6 @@ def after_attach(obj):
             if can_attach:
                 workflow.doActionFor(ws, "attach")
     obj.reindexObject()
+    ar = obj.getRequest()
+    if ar:
+        ar.reindexObject()


### PR DESCRIPTION
Removed the ComputedField `AnalysesNum` from Analysis Request content type, cause it was only used for indexes and the counterpart function is enough. Added more indicators in `getAnalysesNum` function, so now the function returns an array as follows: 
```
[ number of verified analyses, 
  total number of analyses,
  number of analyses with results not yet submitted,
  number of analyses to be verified ]
```
With this Pull Request, the Analysis Request object is reindexed (so `getAnalysesNum` is re-indexed) after a transition to any analysis is performed.

Although the "Number of Analyses" column hasn't been removed from Analysis Requests lists, this PR adds a new column that takes advantage of this information and makes easier for the user to know the current percentage of completeness of each Analysis Request:

![progress](https://user-images.githubusercontent.com/832627/29829044-adade1e6-8cde-11e7-853f-fea263e9311e.png)

