### PR TITLE
Performance optimizations in Analysis Request creation

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -1762,10 +1762,11 @@ function AnalysisRequestAddByCol() {
             // Expand category
             var service = service_data[si]
             services.push(service)
-            var th = $("table[form_id='" + service['PointOfCapture'] + "'] " +
-                       "th[cat='" + service['CategoryTitle'] + "']")
-            if(expanded_categories.indexOf(th) < 0) {
-                expanded_categories.push(th)
+            var th_key = "table[form_id='" + service['PointOfCapture'] + "'] " +
+                       "th[cat='" + service['CategoryTitle'] + "']"
+            var th = $(th_key)
+            if(expanded_categories.indexOf(th_key) < 0) {
+                expanded_categories.push(th_key)
                 var def = $.Deferred()
                 def = category_header_expand_handler(th)
                 defs.push(def)

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -66,15 +66,3 @@ def ObjectModifiedEventHandler(obj, event):
             brains = cat(portal_type=i[0], getCategoryUID=obj.UID())
             for brain in brains:
                 brain.getObject().reindexObject(idxs=['getCategoryTitle'])
-    # TODO: This is a workaround in order to reindex the getBatchUID index
-    # of analyses when the analysis request has been modified. When the
-    # ReferenceField 'batch' is modified (and because it is reference field)
-    # only the archetype 'Reference' object is flagged as modified, not
-    # the whole AnalysisRequest. We need to migrate that reference field
-    # to the new ones.
-    # For now, we will take advantage of that reference object and we will
-    # reindex only the getbatchUID.
-    elif IAnalysisRequest.providedBy(obj.aq_parent.aq_inner):
-        analyses = obj.getAnalyses()
-        for analysis in analyses:
-            analysis.getObject().reindexObject(idxs=['getBatchUID'])

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -84,11 +84,11 @@ def doActionFor(instance, action_id, active_only=True, allowed_transition=True):
     workflow = getToolByName(instance, "portal_workflow")
     skipaction = skip(instance, action_id, peek=True)
     if skipaction:
-        clazzname = instance.__class__.__name__
-        msg = "Skipping transition '{0}': {1} '{2}'".format(action_id,
-                                                            clazzname,
-                                                            instance.getId())
-        logger.info(msg)
+        #clazzname = instance.__class__.__name__
+        #msg = "Skipping transition '{0}': {1} '{2}'".format(action_id,
+        #                                                    clazzname,
+        #                                                    instance.getId())
+        #logger.info(msg)
         return actionperformed, message
 
     if allowed_transition:
@@ -319,11 +319,8 @@ def wasTransitionPerformed(instance, transition_id):
     """Checks if the transition has already been performed to the object
     Instance's workflow history is checked.
     """
-    review_history = getReviewHistory(instance)
-    for event in review_history:
-        if event['action'] == transition_id:
-            return True
-    return False
+    transitions = getReviewHistoryActionsList(instance)
+    return transition_id in transitions
 
 
 def isActive(instance):


### PR DESCRIPTION
This Pull Request contains very small changes, but it makes ~185 analyses from a Profile or Template get populated in less than 3s in AR Add form, even with the creation of 4 Analysis Request at once. With this PR, a delay because of BatchUID reindexing on analyses has been fixed too. As a result, the process of creation of an Analysis Request is significantly faster than before:

- Creation of 1 Analysis Request with 184 analyses: before ~3m, after ~1m5s.
- Creation of 1 Analysis Request with 94 analyses: before ~2m, after ~30s.

For these numbers, a laptop has been used, with a standalone instance, started in fg mode and with other applications (email, firefox, openoffice and PyCharm) running, so the numbers should be better in a dedicated server with an instance with zeo mode.

Breakdown of processes that take more than 1s during the creation of an AR with 94 analyses:
a) [Submission of form](https://github.com/naralabs/bika.lims/blob/d827845190fd78ba55fe2359dee73152ae61cfb7/bika/lims/utils/analysisrequest.py#L72-L76): ~15s 
b) [Transition of AR to sampled](https://github.com/naralabs/bika.lims/blob/d827845190fd78ba55fe2359dee73152ae61cfb7/bika/lims/utils/analysisrequest.py#L118-L130) : ~8s
c) [Transition of AR to sample_due](https://github.com/naralabs/bika.lims/blob/d827845190fd78ba55fe2359dee73152ae61cfb7/bika/lims/utils/analysisrequest.py#L154-L170): ~8s

The most time-consuming task is the creation of the AR by using the ``ar.processForm(REQUEST=request, values=values)`` https://github.com/naralabs/bika.lims/blob/d827845190fd78ba55fe2359dee73152ae61cfb7/bika/lims/utils/analysisrequest.py#L75, but don't think there is too much room for improvement here unless we remove fields from the Schema and ensure there is no Created/ModifiedEventHandlers that makes the system to be slow. In any case, worth to review in detail.

Regarding transitions, there is still window for improvement, specially because the Analysis Request object (as well as Sample, Partitions and Analyses) needs to be transitioned several times (sample_received -> sampled -> sample_received) before reaching the desired state. There is some overhead because of transitions cascading and promotion, and there is work going on to address these shortcomings already.
