### PR TITLE
Missed to add getPrioritySortkey as index and metadata in catalog

### DIFF
--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -51,6 +51,7 @@ _indexes_dict = {
     'getAnalysisRequestPrintStatus': 'FieldIndex',
     'getWorksheetUID': 'FieldIndex',
     'getOriginalReflexedAnalysisUID': 'FieldIndex',
+    'getPrioritySortkey': 'FieldIndex',
 }
 # Defining the columns for this catalog
 _columns_list = [
@@ -96,6 +97,7 @@ _columns_list = [
     'getVerificators',
     'getLastVerificator',
     'getIsReflexAnalysis',
+    'getPrioritySortkey',
     # TODO-performance: All that comes from services could be
     # defined as a service metacolumn instead of an analysis one
     'getResultOptions',


### PR DESCRIPTION
Although `getPrioritySortkey` was added in upgrade step 17.08: https://github.com/naralabs/bika.lims/blob/20a6038c782d7225d8aebfaba6e3ffdbf0c711f4/bika/lims/upgrade/v3_2_0_1708.py#L47-L48 , it was missing in `bika.lims.catalog.analysis_catalog`, so with a fresh instance, the following error raises in Add Analyses view when creating a Worksheet:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.worksheet.views.add_analyses, line 156, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 3f8478a896e2e94124702d820b4e1a3a.py, line 1203, in render
  Module 544e3f4222344969d339c161e7634751.py, line 1172, in render_master
  Module 544e3f4222344969d339c161e7634751.py, line 484, in render_content
  Module 3f8478a896e2e94124702d820b4e1a3a.py, line 1132, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1316, in contents_table
  Module bika.lims.browser.bika_listing, line 1410, in __init__
  Module bika.lims.browser.worksheet.views.add_analyses, line 201, in folderitems
  Module bika.lims.browser.bika_listing, line 1046, in folderitems
  Module bika.lims.browser.worksheet.views.add_analyses, line 221, in folderitem
AttributeError: getPrioritySortkey
```