### PR TITLE
NDEV-50 Sort on column or index is not valid

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -599,12 +599,18 @@ class BikaListingView(BrowserView):
         self.sort_order = self.request.get(form_id + '_sort_order', self.sort_order)
         self.manual_sort_on = self.request.get(form_id + '_manual_sort_on', None)
 
+        # When Column header with 'index' is clicked, we replace 'self.sort_on' value with its index to
+        # fill 'self.contentFilter'. sort_column_name variable will be used to reset
+        # 'self.sort_on' value to its initial value. 'sort_on' must always be a column name, otherwise
+        # GET_url generates malformed url.
+        sort_column_name = None
         if self.sort_on:
             if self.sort_on in self.columns.keys():
                if self.columns[self.sort_on].get('index', None):
                    self.request.set(form_id+'_sort_on', self.sort_on)
                    # The column can be sorted directly using an index
                    idx = self.columns[self.sort_on]['index']
+                   sort_column_name = self.sort_on
                    self.sort_on = idx
                    # Don't sort manually!
                    self.manual_sort_on = None
@@ -643,6 +649,8 @@ class BikaListingView(BrowserView):
         self.contentFilter['sort_order'] = self.sort_order
         if self.sort_on:
             self.contentFilter['sort_on'] = self.sort_on
+            if sort_column_name:
+                self.sort_on = sort_column_name
 
         # pagesize
         pagesize = self.request.get(form_id + '_pagesize', self.pagesize)

--- a/bika/lims/skins/bika/bika_listing.css.dtml
+++ b/bika/lims/skins/bika/bika_listing.css.dtml
@@ -174,6 +174,11 @@ table.bika-listing-table {
   padding-right:1.5em;
   color: tableHeaderTextColor;
 }
+.bika-listing-table th.sortable.reverse{
+  background: &dtml-tableHeaderBackgroundColor; url(arrowDown.png) 95% 50% no-repeat;
+  padding-right:1.5em;
+  color: tableHeaderTextColor;
+}
 
 .bika-listing-table th.ascending.indexed{
   background: &dtml-tableHeaderBackgroundColor; url(arrowUpAlternative.png) 95% 50% no-repeat !important;


### PR DESCRIPTION
There is a bug/confusion in bika_listing's sorting algorithm.
We know that there is 'columns' dictionary in each listing view. Each item in that dictionary contains 'id' of the column and different options of that column.
```
self.columns = {
            'getRequestID': {
                'title': _('Request ID'),
                'attr': 'getId',
                'replace_url': 'absolute_url',
                'index': 'getId'},
            'getClientOrderNumber': {
                'title': _('Client Order'),
                'sortable': False,
                'toggle': True},
         }
```

One of the keys of column values is 'index' which must be used to sort folder items, if its column has chosen to be sorted on. It works properly when clicked on table headers to sort. However, when 'review_states' is changed, that 'sort_on' fails. Apparently, the reason underlies URL of 'review_state' buttons. The URLs should contain column ID where now they directly contain index ID.