### PR TITLE
Sample point field can't be modified in some cases

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -142,7 +142,17 @@ function AnalysisRequestViewView() {
                         base_query["getClientUID"] = [data['ClientUID'], setup_uid];
                         $(spelement).attr("base_query", $.toJSON(base_query));
                         var options = $.parseJSON($(spelement).attr("combogrid_options"));
-                        options.url = window.location.href.split("/ar")[0] + "/" + options.url;
+                        // Getting the url like that will return the query
+                        // part of it:
+                        // http://localhost:8080/Plone/clients/client17-14/..
+                        //    ..OA17-0030-R01?check_edit=1
+                        // In order to create a correct ajax call
+                        // we only need until the pathname of that url:
+                        // http://localhost:8080/Plone/clients/client17-14/..
+                        //    ..OA17-0030-R01
+                        var simple_url = window.location.href.split("/ar")[0];
+                        simple_url = simple_url.split('?')[0];
+                        options.url = simple_url + "/" + options.url;
                         options.url = options.url + "?_authenticator=" + $("input[name='_authenticator']").val();
                         options.url = options.url + "&catalog_name=" + $(spelement).attr("catalog_name");
                         options.url = options.url + "&base_query=" + $.toJSON(base_query);


### PR DESCRIPTION
During the renderization of AnalysisRequestView, attributes of SamplePoint widgets were being updated with JavaScript. There, the URL to create AJAX requests was being obtained but the query part was included. So that AJAX request were failing.