### PR TITLE
Fine-grained visibility of analyses in results reports and client views

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -1189,11 +1189,8 @@ class AnalysisRequestDigester:
                 full_objects=True, review_state=analysis_states):
 
             # Omit hidden analyses?
-            if not showhidden:
-                asets = ar.getAnalysisServiceSettings(an.getServiceUID())
-                if asets.get('hidden'):
-                    # Hide analysis
-                    continue
+            if not showhidden and an.getHidden():
+                continue
 
             # Build the analysis-specific dict
             andict = self._analysis_data(an, dm)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -813,6 +813,14 @@ class BikaListingView(BrowserView):
         """
         pass
 
+    def remove_column(self, column):
+        """Removes the column passed-in, if exists"""
+        if column in self.columns:
+            del self.columns[column]
+            for item in self.review_states:
+                if column in item.get('columns', []):
+                    item['columns'].remove(column)
+
     def __call__(self):
         """ Handle request parameters and render the form."""
 

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -674,6 +674,9 @@ function BikaListingTableView() {
          */
         var fieldvalue, fieldname, requestdata={}, uid, tr;
         fieldvalue = $(pointer).val();
+        if ($(pointer).is(':checkbox')) {
+            fieldvalue = $(pointer).is(':checked');
+        }
         fieldname = $(pointer).attr('field');
         tr = $(pointer).closest('tr');
         uid = $(pointer).attr('uid');
@@ -689,7 +692,6 @@ function BikaListingTableView() {
         var url = window.location.href.replace('/base_view', '');
         // Staff for the notification
         var name = $(tr).attr('title');
-        var anch =  "<a href='"+ url + "'>" + name + "</a>";
         $.ajax({
             type: "POST",
             url: window.portal_url+"/@@API/update",
@@ -698,18 +700,18 @@ function BikaListingTableView() {
         .done(function(data) {
             //success alert
             if (data != null && data['success'] == true) {
-                bika.lims.SiteView.notificationPanel(anch + ': ' + name + ' updated successfully', "succeed");
+                bika.lims.SiteView.notificationPanel(name + ' updated successfully', "succeed");
             } else {
-                bika.lims.SiteView.notificationPanel('Error while updating ' + name + ' for '+ anch, "error");
-                var msg = '[bika.lims.analysisrequest.js] Error while updating ' + name + ' for '+ ar;
+                bika.lims.SiteView.notificationPanel('Error while updating ' + name, "error");
+                var msg = 'Error while updating ' + name;
                 console.warn(msg);
                 window.bika.lims.error(msg);
             }
         })
         .fail(function(){
             //error
-            bika.lims.SiteView.notificationPanel('Error while updating ' + name + ' for '+ anch, "error");
-            var msg = '[bika.lims.analysisrequest.js] Error while updating ' + name + ' for '+ ar;
+            bika.lims.SiteView.notificationPanel('Error while updating ' + name, "error");
+            var msg = 'Error while updating ' + name;
             console.warn(msg);
             window.bika.lims.error(msg);
         });

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -88,6 +88,16 @@ Uncertainty = FixedPointField(
         label=_("Uncertainty")
     )
 )
+# This field keep track if the field hidden has been set manually or not. If
+# this value is false, the system will assume the visibility of this analysis
+# in results report will depend on the value set at AR, Profile or Template
+# levels (see AnalysisServiceSettings fields in AR). If the value for this
+# field is set to true, the system will assume the visibility of the analysis
+# will only depend on the value set for the field Hidden (bool).
+HiddenManually = BooleanField(
+    'HiddenManually',
+    default=False,
+)
 
 schema = schema.copy() + Schema((
     IsReflexAnalysis,
@@ -98,6 +108,7 @@ schema = schema.copy() + Schema((
     ReflexRuleLocalID,
     SamplePartition,
     Uncertainty,
+    HiddenManually,
 ))
 
 
@@ -423,6 +434,44 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         analysis_request = self.getRequest()
         if analysis_request:
             return analysis_request.getPrioritySortkey()
+
+    @security.public
+    def getHidden(self):
+        """ Returns whether if the analysis must be displayed in results
+        reports or not, as well as in analyses view when the user logged in
+        is a Client Contact.
+
+        If the value for the field HiddenManually is set to False, this function
+        will delegate the action to the method getAnalysisServiceSettings() from
+        the Analysis Request.
+
+        If the value for the field HiddenManually is set to True, this function
+        will return the value of the field Hidden.
+        :return: true or false
+        """
+        if self.getHiddenManually():
+            return self.getSchema().getField('Hidden').get(self)
+        request = self.getRequest()
+        if request:
+            service_uid = self.getServiceUID()
+            ar_settings = request.getAnalysisServiceSettings(service_uid)
+            return ar_settings.get('hidden', False)
+        return False
+
+    @security.public
+    def setHidden(self, hidden):
+        """ Sets if this analysis must be displayed or not in results report and
+        in manage analyses view if the user is a lab contact as well.
+
+        The value set by using this field will have priority over the visibility
+        criteria set at Analysis Request, Template or Profile levels (see
+        field AnalysisServiceSettings from Analysis Request. To achieve this
+        behavior, this setter also sets the value to HiddenManually to true.
+        :param hidden: true if the analysis must be hidden in results
+        :rtype hidden: bool
+        """
+        self.setHiddenManually(True)
+        self.Schema().getField('Hidden').set(self, hidden)
 
     @security.public
     def setReflexAnalysisOf(self, analysis):

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -448,9 +448,10 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         If the value for the field HiddenManually is set to True, this function
         will return the value of the field Hidden.
         :return: true or false
+        :rtype: bool
         """
         if self.getHiddenManually():
-            return self.getSchema().getField('Hidden').get(self)
+            return self.getField('Hidden').get(self)
         request = self.getRequest()
         if request:
             service_uid = self.getServiceUID()
@@ -467,11 +468,11 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         criteria set at Analysis Request, Template or Profile levels (see
         field AnalysisServiceSettings from Analysis Request. To achieve this
         behavior, this setter also sets the value to HiddenManually to true.
-        :param hidden: true if the analysis must be hidden in results
-        :rtype hidden: bool
+        :param hidden: true if the analysis must be hidden in report
+        :type hidden: bool
         """
         self.setHiddenManually(True)
-        self.Schema().getField('Hidden').set(self, hidden)
+        self.getField('Hidden').set(self, hidden)
 
     @security.public
     def setReflexAnalysisOf(self, analysis):

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1031,11 +1031,13 @@ h2 a.add-button {
     padding: 5px 20px 20px 70px;
 }
 div#viewlet-above-content-title #panel-notification {
-    left: 0;
-    margin: 100px;
-    padding: 0 280px;
-    position: absolute;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     z-index: 1000;
+    border: 1px solid #efefef;
+    box-shadow: 1px 1px 10px #fff;
 }
 div#viewlet-above-content-title #panel-notification div.error-notification-item {
     background: url("/Plone/++resource++bika.lims.images/warning.png") no-repeat scroll 15px center #fff680;

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -50,7 +50,7 @@ def copy_analysis_field_values(source, analysis, **kwargs):
         'creators', 'effectiveDate', 'expirationDate', 'language', 'rights',
         'creation_date', 'modification_date', 'IsReflexAnalysis',
         'OriginalReflexedAnalysis', 'ReflexAnalysisOf', 'ReflexRuleAction',
-        'ReflexRuleLocalID', 'ReflexRuleActionsTriggered']
+        'ReflexRuleLocalID', 'ReflexRuleActionsTriggered', 'Hidden']
     for field in src_schema.fields():
         fieldname = field.getName()
         if fieldname in IGNORE_FIELDNAMES and fieldname not in kwargs:


### PR DESCRIPTION
The default visibility of a given analysis in result reports (or when the current user is a Client Contact) can be established beforehand by making use of an Analysis Profile or an Analysis Template. Another option is to define their visibility once created, at Analysis Request level, in Manage Analyses tab. As part of the Reflex Testing functionality, one can create automated rules that, amongst other actions, can generate duplicates, retests, etc. Because of this behavior, an Analysis Request will usually end up containing more than one analysis of the same type (Analysis Service). Therefore, the assignment of visibility with the above mentioned tools, which use Analysis Services instead of analyses, is clearly not enough: labman must be able to choose which intermediate or final results generated due to the actions triggered within a reflex rule process have to be displayed in results report or accessible to client, regardless of their "type".

With this Pull Request, a checkbox is displayed in the Analyses list from inside Analysis Request, so the user with "Add Analyses" privileges (typically labman) will be able to set the visibility at analysis level. By default, the visibility assigned to a given analysis is determined by the mechanisms that are already in place (Analysis Service visibility at Analysis Request, Analysis Profile and Analysis Template levels). When the visibility is set at analysis level, this setting prevails over the rest of criteria. The visibility can be set also if the analysis has been verified or published already, cause this setting does not affect the results and is mainly for presentation purposes.

![hidden](https://user-images.githubusercontent.com/832627/29950273-f0ab5cf2-8eba-11e7-8a56-a95dfde0a99f.png)
