### PR TITLE
NMRL-190 Visibility of automatically created analyses because of reflex rules actions

### DIFF
--- a/bika/lims/browser/fields/reflexrulefield.py
+++ b/bika/lims/browser/fields/reflexrulefield.py
@@ -270,7 +270,7 @@ def _check_actions(instance, actions):
             logger.warn('The act_row_idx must be a number. Now its value is: '
                         '%s' % (act_row_idx))
             return False
-        if action_name not in ['repeat', 'duplicate', 'setresult']:
+        if action_name not in ['repeat', 'duplicate', 'setresult','setvisibility']:
             logger.warn(
                 'Not correct action_name value')
             return False

--- a/bika/lims/browser/widgets/reflexrulewidget.py
+++ b/bika/lims/browser/widgets/reflexrulewidget.py
@@ -153,7 +153,6 @@ class ReflexRuleWidget(RecordsWidget):
         }
         """
         keys = raw_data.keys()
-        import pdb; pdb.set_trace()
         # 'formatted_action_row' is the dict which will be added in the
         # 'value' list
         formatted_set = {}
@@ -264,6 +263,9 @@ class ReflexRuleWidget(RecordsWidget):
             # Getting the local analysis id
             worksheettemplate_key = 'worksheettemplate-'+str(a_count)
             worksheettemplate = raw_set.get(worksheettemplate_key, '')
+            # Getting the visibility in report
+            showinreport_key = 'showinreport-'+str(a_count)
+            showinreport = raw_set.get(showinreport_key, '')
             # Building the action dict
             action_dict = {
                 'action': raw_set[key],
@@ -275,6 +277,7 @@ class ReflexRuleWidget(RecordsWidget):
                 'setresultdiscrete': setresultdiscrete,
                 'setresultvalue': setresultvalue,
                 'an_result_id': local_id,
+                'showinreport': showinreport,
                 }
             # Saves the action as a new dict inside the actions list
             actions_dicts_l.append(action_dict)

--- a/bika/lims/browser/widgets/reflexrulewidget.py
+++ b/bika/lims/browser/widgets/reflexrulewidget.py
@@ -266,6 +266,9 @@ class ReflexRuleWidget(RecordsWidget):
             # Getting the visibility in report
             showinreport_key = 'showinreport-'+str(a_count)
             showinreport = raw_set.get(showinreport_key, '')
+            # Getting the analysis to show or hide in report
+            setvisibilityof_key = 'setvisibilityof-'+str(a_count)
+            setvisibilityof = raw_set.get(setvisibilityof_key, '')
             # Building the action dict
             action_dict = {
                 'action': raw_set[key],
@@ -278,6 +281,7 @@ class ReflexRuleWidget(RecordsWidget):
                 'setresultvalue': setresultvalue,
                 'an_result_id': local_id,
                 'showinreport': showinreport,
+                'setvisibilityof': setvisibilityof,
                 }
             # Saves the action as a new dict inside the actions list
             actions_dicts_l.append(action_dict)
@@ -431,7 +435,8 @@ class ReflexRuleWidget(RecordsWidget):
         return DisplayList([
             ('repeat', 'Repeat'),
             ('duplicate', 'Duplicate'),
-            ('setresult', 'Set result')])
+            ('setresult', 'Set result'),
+            ('setvisibility', 'Set Visibility')])
 
     def getShowInRepVoc(self):
         """

--- a/bika/lims/browser/widgets/reflexrulewidget.py
+++ b/bika/lims/browser/widgets/reflexrulewidget.py
@@ -443,6 +443,7 @@ class ReflexRuleWidget(RecordsWidget):
         Return the different Visibility in Report values.
         """
         return DisplayList([
+            ('default', 'Visibility (default)'),
             ('visible', 'Show in Report'),
             ('invisible', 'Hide In Report')])
 

--- a/bika/lims/browser/widgets/reflexrulewidget.py
+++ b/bika/lims/browser/widgets/reflexrulewidget.py
@@ -1,23 +1,13 @@
-from AccessControl import ClassSecurityInfo
-from Products.Archetypes.Registry import registerWidget
-from Products.Archetypes.interfaces import IVocabulary
-from zope.interface import implements
-from Products.Archetypes.public import DisplayList
-from Products.CMFCore.utils import getToolByName
-from zope.schema.vocabulary import SimpleVocabulary
-from zope.schema.vocabulary import SimpleTerm
-from bika.lims.utils import getUsers
-from bika.lims.browser.widgets import RecordsWidget
-from bika.lims.browser.widgets.reflexrulewidget_description import description
-from plone.api.portal import get_tool
 import json
 
-try:
-    from zope.component.hooks import getSite
-except:
-    # Plone < 4.3
-    from zope.app.component.hooks import getSite
-
+from AccessControl import ClassSecurityInfo
+from Products.Archetypes.Registry import registerWidget
+from Products.Archetypes.public import DisplayList
+from Products.CMFCore.utils import getToolByName
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.widgets import RecordsWidget
+from bika.lims.browser.widgets.reflexrulewidget_description import description
+from bika.lims.utils import getUsers
 
 class ReflexRuleWidget(RecordsWidget):
     _properties = RecordsWidget._properties.copy()
@@ -433,19 +423,19 @@ class ReflexRuleWidget(RecordsWidget):
         Return the different action available
         """
         return DisplayList([
-            ('repeat', 'Repeat'),
-            ('duplicate', 'Duplicate'),
-            ('setresult', 'Set result'),
-            ('setvisibility', 'Set Visibility')])
+            ('repeat', _('Repeat')),
+            ('duplicate', _('Duplicate')),
+            ('setresult', _('Set result')),
+            ('setvisibility', _('Set Visibility'))])
 
     def getShowInRepVoc(self):
         """
         Return the different Visibility in Report values.
         """
         return DisplayList([
-            ('default', 'Visibility (default)'),
-            ('visible', 'Show in Report'),
-            ('invisible', 'Hide In Report')])
+            ('default', _('Visibility (default)')),
+            ('visible', _('Show in Report')),
+            ('invisible', _('Hide In Report'))])
 
     def getAndOrVoc(self):
         """

--- a/bika/lims/browser/widgets/reflexrulewidget.py
+++ b/bika/lims/browser/widgets/reflexrulewidget.py
@@ -153,6 +153,7 @@ class ReflexRuleWidget(RecordsWidget):
         }
         """
         keys = raw_data.keys()
+        import pdb; pdb.set_trace()
         # 'formatted_action_row' is the dict which will be added in the
         # 'value' list
         formatted_set = {}
@@ -428,6 +429,14 @@ class ReflexRuleWidget(RecordsWidget):
             ('repeat', 'Repeat'),
             ('duplicate', 'Duplicate'),
             ('setresult', 'Set result')])
+
+    def getShowInRepVoc(self):
+        """
+        Return the different Visibility in Report values.
+        """
+        return DisplayList([
+            ('visible', 'Show in Report'),
+            ('invisible', 'Hide In Report')])
 
     def getAndOrVoc(self):
         """

--- a/bika/lims/content/reflexrule.py
+++ b/bika/lims/content/reflexrule.py
@@ -346,11 +346,9 @@ def doActionToAnalysis(base, action):
         base.getReflexRuleActionsTriggered()
     )
     if action.get('showinreport', '') == "invisible":
-        visibility = False
-        analysis.setHidden(visibility)
+        analysis.setHidden(False)
     elif action.get('showinreport', '') == "visible":
-        visibility = True
-        analysis.setHidden(visibility)
+        analysis.setHidden(True)
     # Setting the original reflected analysis
     if base.getOriginalReflexedAnalysis():
         analysis.setOriginalReflexedAnalysis(

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
@@ -557,18 +557,24 @@ jQuery(function($){
         });
     }
 
+    /**
+     * This function handles 'setvisibilityof' select elements' selected value
+     * Parses setup data, and makes the proper option be selected.
+     * @param {string} setupdata an object containing the setup data.
+     */
     function setup_svof(setupdata){
-        /**
-        */
         var rules = setupdata.saved_actions.rules;
         var rulescontainers = $('td.rulescontainer');
 
         $.each(rulescontainers,function(index1, element1){
             var action_set_div = $(element1).find('div[id^="ReflexRules-actionsset-"]');
+            // 'action_divs' are "lines" of each 'action_set_div'.
             var action_divs = $(action_set_div).find('div[class="action"]');
+            // This actions variable is actually actions sets.
             var actions = rules[index1].actions;
 
             $.each(action_divs,function(index2, element2){
+                // Now from each "line", we are getting select element.
                 var sv_select = $(element2).find('select[id^="ReflexRules-setvisibilityof-"]');
                 sv = actions[index2].setvisibilityof;
                 $(sv_select).find('option[value="'+ sv + '"]')
@@ -694,11 +700,13 @@ jQuery(function($){
         else if(selection=="setvisibility"){
             // Hide the temporary ID for this analysis
             $(action_div).find('input[id^=ReflexRules-an_result_id-]').hide();
+            // Hide fields of the other actions
             $(action_div).find('div.action_define_result').hide();
             $(action_div).find('div.to_other_worksheet').hide();$(action_div)
                 .find('div.to_other_worksheet')
                 .find('select[id^="ReflexRules-otherWS-"]').find(":selected")
                 .prop("selected", false);
+            // Show analysis id selector
             $(action_div).find('div.action_define_visibility').show();
             local_id = $(action_div).find("input[id^='ReflexRules-an_result_id-']")
                 .first().val();
@@ -847,10 +855,15 @@ jQuery(function($){
             options = options.sort();
             $(element).append(options.join(''));
         });
-
+        // Now update analysis selectors of 'setvisibility' actions.
         update_visibility_selectors();
     }
 
+    /**
+     * This function updates analysis local ids in 'setvisibilityof' options list.
+     * Onnly ids form previous containers can be added. Also adding 'Orginial Analysis'
+     * since it doesn't have a local id.
+     */
     function update_visibility_selectors() {
         // Getting the selectors from the containers.
         var selectors = $("select[id^='ReflexRules-setvisibilityof-']");

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
@@ -62,6 +62,7 @@ jQuery(function($){
         });
         // Setting up the selected analysis services outside the main rule
         setup_as(setupdata);
+        setup_svof(setupdata);
         // Setting up the worksheet templates select options
         setup_worksheettemplate(setupdata);
     });
@@ -556,6 +557,27 @@ jQuery(function($){
         });
     }
 
+    function setup_svof(setupdata){
+        /**
+        */
+        var rules = setupdata.saved_actions.rules;
+        var rulescontainers = $('td.rulescontainer');
+
+        $.each(rulescontainers,function(index1, element1){
+            var action_set_div = $(element1).find('div[id^="ReflexRules-actionsset-"]');
+            var action_divs = $(action_set_div).find('div[class="action"]');
+            var actions = rules[index1].actions;
+
+            $.each(action_divs,function(index2, element2){
+                var sv_select = $(element2).find('select[id^="ReflexRules-setvisibilityof-"]');
+                sv = actions[index2].setvisibilityof;
+                $(sv_select).find('option[value="'+ sv + '"]')
+                    .prop("selected", true);
+            });
+
+        });
+    }
+
     /**
      * This function looks for all worksheet template 'select' elements and
      * selects their option takeing in consideration the setupdata.
@@ -641,6 +663,7 @@ jQuery(function($){
             // Showing the analyst-section div
             var action_define_div = $(action_div).find('div.action_define_result');
             $(action_define_div).css('display', 'inline');
+            $(action_div).find('div.action_define_visibility').hide();
             $(action_div).find('div.to_other_worksheet').hide();
             $(action_div)
                 .find('div.to_other_worksheet')
@@ -668,12 +691,26 @@ jQuery(function($){
                 $(action_div).find("input[id^='ReflexRules-an_result_id-']")
                     .first().val('');}
         }
+        else if(selection=="setvisibility"){
+            // Hide the temporary ID for this analysis
+            $(action_div).find('input[id^=ReflexRules-an_result_id-]').hide();
+            $(action_div).find('div.action_define_result').hide();
+            $(action_div).find('div.to_other_worksheet').hide();$(action_div)
+                .find('div.to_other_worksheet')
+                .find('select[id^="ReflexRules-otherWS-"]').find(":selected")
+                .prop("selected", false);
+            $(action_div).find('div.action_define_visibility').show();
+            local_id = $(action_div).find("input[id^='ReflexRules-an_result_id-']")
+                .first().val();
+            update_analysis_selectors();
+        }
         else{
             // Show the temporary ID of the analysis to be generated
             $(action_div).find('input[id^=ReflexRules-an_result_id-]').show();
             // Hide the options-set
             $(action_div).find('div.to_other_worksheet').css('display', 'inline');
             $(action_div).find('div.action_define_result').hide();
+            $(action_div).find('div.action_define_visibility').hide();
             if (!first_setup){
                 local_id = new_localid(selection);
                 $(action_div).find("input[id^='ReflexRules-an_result_id-']")
@@ -807,6 +844,35 @@ jQuery(function($){
                 prevtr = $(prevtr).prev();
             }
             // Sort the options and add them to the selection list
+            options = options.sort();
+            $(element).append(options.join(''));
+        });
+
+        update_visibility_selectors();
+    }
+
+    function update_visibility_selectors() {
+        // Getting the selectors from the containers.
+        var selectors = $("select[id^='ReflexRules-setvisibilityof-']");
+        $.each($(selectors), function(index, element){
+            var options = [];
+            var selected = $('#'+$(element).attr('id')+" :selected").text();
+            $(element).find('option').remove();
+            // We fetch the local-ids from previous rows (rules)
+            var prevtr = $(element).closest('tr').prev();
+            while ($(prevtr).hasClass('records_row_ReflexRules')) {
+                $(prevtr).find('.derivative-id').each(function(index, el2) {
+                    var did = $(el2).val();
+                    if (did !== '') {
+                        var optd = did == selected ? " selected" : "";
+                        options.push('<option value="'+did+'"'+optd+'>'+did+'</option>');
+                    }
+                });
+                prevtr = $(prevtr).prev();
+            }
+            // Add Original analysis to the list,
+            // sort the options and add them to the selection list
+            options.push('<option value="original">Original Analysis</option>');
             options = options.sort();
             $(element).append(options.join(''));
         });

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.pt
@@ -308,6 +308,23 @@
                                     value python:widget.getReflexRuleActionElement(idx, act_row_idx, 'setresultvalue');"
                                     i18n:domain="python:i18n_domain">
                         </div>
+                        <div class="action_define_visibility inline">
+                            <span i18n:translate="" class="reflex_rule_text"> of </span>
+                            <!-- Define to which analysis to show or to hide
+                            (repeating the analysis) -->
+                            <select
+                                tal:define="
+                                    act_row_idx python:action_row['act_row_idx'];"
+                                tal:attributes="
+                                    name string:${fieldName}.setvisibilityof-${act_row_idx}:records:ignore_empty;
+                                    id string:${fieldName}-setvisibilityof-${repeat/idx/index}-${act_row_idx};
+                                    tabindex tabindex/next|nothing;"
+                                    i18n:domain="python:i18n_domain">
+                                <option
+                                    i18n:translate=""/>
+                            </select>
+                            <span i18n:translate="" class="reflex_rule_text">as</span>
+                        </div>
                         <div class="to_other_worksheet inline">
                             <!-- Other worksheet selector -->
                             <select

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.pt
@@ -371,6 +371,23 @@
                                 </select>
                             </div>
                         </div>
+                        <div class="show_in_report inline">
+                            <select
+                                tal:define="
+                                    act_row_idx python:action_row['act_row_idx'];
+                                    olist widget/getShowInRepVoc"
+                                tal:attributes="
+                                    name string:${fieldName}.showinreport-${act_row_idx}:records:ignore_empty;
+                                    id string:${fieldName}-showinreport-${repeat/idx/index}-${act_row_idx};">
+                                <option
+                                    tal:repeat="option olist"
+                                    tal:content="python:olist.getValue(option)"
+                                    tal:attributes="
+                                        value python: option;
+                                        selected python:'selected' if option==action_row['action'] else None"
+                                    i18n:translate=""/>
+                            </select>
+                        </div>
                         <!-- delete action-->
                         <img class="action_deletebtn"
                             tal:attributes="

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.pt
@@ -384,7 +384,7 @@
                                     tal:content="python:olist.getValue(option)"
                                     tal:attributes="
                                         value python: option;
-                                        selected python:'selected' if option==action_row['action'] else None"
+                                        selected python:'selected' if option==action_row.get('showinreport', '') else None"
                                     i18n:translate=""/>
                             </select>
                         </div>


### PR DESCRIPTION
Currently, all analyses of AR are visible/invisible in final report depending of their Default AS settings. In some cases it is not necessary to show original (base) analysis or other duplicated analyses which don't contain final result. This pull request aims to let users define visibility of duplicated/repeated analyses in Reflex Rule level. However, it is possible to update that value from 'Manage Results' view with enough privileges. For more information about visibility settings of analyses, please see https://github.com/naralabs/bika.lims/pull/241 . 

With this Pull Request new action- 'Set visibility', will be added to the actions list of Reflex Rules. Moreover, for 'Repeat' and 'Duplicate' actions (which they create new analysis) there will be new select field as well to show or hide new analysis.

In the attached image you can see a simple example of this new feature.

![image](https://user-images.githubusercontent.com/23520079/29962886-17d9337c-8f05-11e7-9f0b-f8ce28398387.png)

