### PR TITLE
Asynchronous creation of Analysis Requests

### DIFF
--- a/bika/lims/browser/analysisrequest/__init__.py
+++ b/bika/lims/browser/analysisrequest/__init__.py
@@ -41,6 +41,7 @@ from .published_results import AnalysisRequestPublishedResults
 from .results_not_requested import AnalysisRequestResultsNotRequestedView
 from .workflow import AnalysisRequestWorkflowAction
 from .analysisrequests import AnalysisRequestsView
+from .analysisrequests import QueuedAnalysisRequestsCount
 
 
 class ResultOutOfRange(object):

--- a/bika/lims/browser/analysisrequest/add.py
+++ b/bika/lims/browser/analysisrequest/add.py
@@ -21,6 +21,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from zope.component import getAdapter
 from zope.interface import implements
+from collective.taskqueue import taskqueue
 import traceback
 
 
@@ -368,6 +369,22 @@ def ajax_form_error(errors, field=None, arnum=None, message=None):
     else:
         error_key = 'Form Error'
     errors[error_key] = message
+
+
+class ajaxAnalysisRequestSubmitAsync():
+
+    def __call__(self):
+        #task_queue = queryUtility(ITaskQueue, name=queue_name)
+        #if task_queue is None:
+            # No async
+        #    pass
+        # taskqueue is available, create AR asynchronously
+        # task_queue.queue = Queue.Queue()
+        path = self.request.PATH_INFO
+        path = path.replace('_submit_async', '_submit')
+        taskqueue.add(path, method='POST', queue='ar-create')
+        return json.dumps({'success': 'With taskqueue'})
+
 
 class ajaxAnalysisRequestSubmit():
     """Handle data submitted from analysisrequest add forms.  As much

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -23,6 +23,8 @@ from Products.Archetypes import PloneMessageFactory as PMF
 from plone.app.layout.globals.interfaces import IViewView
 from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
+from collective.taskqueue.interfaces import ITaskQueue
+from zope.component import getUtility
 from datetime import datetime, date
 import json
 
@@ -55,7 +57,6 @@ class AnalysisRequestsView(BikaListingView):
             self.view_url = self.view_url + "/analysisrequests"
 
         self.allow_edit = True
-
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
@@ -1024,6 +1025,10 @@ class AnalysisRequestsView(BikaListingView):
                          "<img src='++resource++bika.lims.images/submitted-by-current-user.png' title='%s'/>" % \
                          t(_("Cannot verify: Submitted by current user"))
         return item
+
+    def pending_tasks(self):
+        task_queue = getUtility(ITaskQueue, name='ar-create')
+        return len(task_queue)
 
     @property
     def copy_to_new_allowed(self):

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -24,7 +24,7 @@ from plone.app.layout.globals.interfaces import IViewView
 from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
 from collective.taskqueue.interfaces import ITaskQueue
-from zope.component import getUtility
+from zope.component import queryUtility
 from datetime import datetime, date
 import json
 
@@ -1027,8 +1027,10 @@ class AnalysisRequestsView(BikaListingView):
         return item
 
     def pending_tasks(self):
-        task_queue = getUtility(ITaskQueue, name='ar-create')
-        return len(task_queue)
+        task_queue = queryUtility(ITaskQueue, name='ar-create')
+        if task_queue:
+            return len(task_queue)
+        return 0
 
     @property
     def copy_to_new_allowed(self):

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -89,6 +89,14 @@
     />
 
     <browser:page
+      for="bika.lims.interfaces.IAnalysisRequestsFolder"
+      name="queued_ars"
+      class="bika.lims.browser.analysisrequest.QueuedAnalysisRequestsCount"
+      permission="bika.lims.ManageAnalysisRequests"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+    <browser:page
       for="*"
       name="secondary_ar_sample_info"
       class="bika.lims.browser.analysisrequest.add.SecondaryARSampleInfo"

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -81,6 +81,14 @@
     />
 
     <browser:page
+      for="bika.lims.interfaces.IAnalysisRequest"
+      name="ar_add_async"
+      class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
+      permission="bika.lims.ManageAnalysisRequests"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+    <browser:page
       for="*"
       name="secondary_ar_sample_info"
       class="bika.lims.browser.analysisrequest.add.SecondaryARSampleInfo"
@@ -148,6 +156,14 @@
       for="*"
       name="analysisrequest_submit"
       class="bika.lims.browser.analysisrequest.add.ajaxAnalysisRequestSubmit"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+    <browser:page
+      for="*"
+      name="analysisrequest_submit_async"
+      class="bika.lims.browser.analysisrequest.add.ajaxAnalysisRequestSubmitAsync"
       permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
     />

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -155,7 +155,7 @@
     <browser:page
       for="*"
       name="analysisrequest_submit"
-      class="bika.lims.browser.analysisrequest.add.ajaxAnalysisRequestSubmit"
+      class="bika.lims.browser.analysisrequest.add.AnalysisRequestSubmit"
       permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
     />
@@ -163,7 +163,7 @@
     <browser:page
       for="*"
       name="analysisrequest_submit_async"
-      class="bika.lims.browser.analysisrequest.add.ajaxAnalysisRequestSubmitAsync"
+      class="bika.lims.browser.analysisrequest.add.AsyncAnalysisRequestSubmit"
       permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
     />

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -69,6 +69,24 @@
 </metal:content-description>
 
 <metal:content-core fill-slot="content-core">
+	<tal:queued define="num_tasks python:view.pending_tasks()"
+		 condition="python: num_tasks &gt; 0">
+		 <script type="text/javascript">
+		 	(function( $ ) {
+			$(document).ready(function(){
+				$('.queued-items').not(':visible').slideDown();
+			});
+			}(jQuery));
+		 </script>
+		 <div class="queued-items" style="display:none;">
+			 <span i18n:translate=''>
+				 There are <span class="queued-items-number"
+					   tal:content='python: num_tasks'
+					   i18n:name='num'/> jobs in queue for the creation of new Analysis Requests
+			 </span>.&nbsp;
+			 <a href='' i18n:translate='' class="button">Refresh</a>
+		 </div>
+	</tal:queued>
 	<div id="folderlisting-main-table"
 		tal:content="structure view/contents_table"/>
 

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -69,20 +69,41 @@
 </metal:content-description>
 
 <metal:content-core fill-slot="content-core">
-	<tal:queued define="num_tasks python:view.pending_tasks()"
-		 condition="python: num_tasks &gt; 0">
+	<tal:queued define="num_tasks python:view.pending_tasks()">
 		 <script type="text/javascript">
 		 	(function( $ ) {
 			$(document).ready(function(){
-				$('.queued-items').not(':visible').slideDown();
+				var ar_queue_seconds = 1;
+				var ar_queue_max_seconds = 20;
+				function query_pending() {
+					var url = window.portal_url + "/analysisrequests/queued_ars"
+					$.get(url).done(function(data) {
+						var num_jobs = $.parseJSON(data);
+						var num_jobs = num_jobs['count'];
+						if (parseInt(num_jobs) > 0) {
+							$('.queued-items').not(':visible').slideDown();
+							$('.queued-items-number').html(num_jobs);
+						} else {
+							$('.queued-items:visible').slideUp();
+							if (ar_queue_seconds > ar_queue_max_seconds) {
+								ar_queue_seconds = ar_queue_max_seconds;
+							} else {
+								ar_queue_seconds = ar_queue_seconds*2;
+							}
+							setTimeout(function() {
+								query_pending();
+							}, ar_queue_seconds * 1000);
+						}
+					});
+				}
+				query_pending();
 			});
 			}(jQuery));
 		 </script>
 		 <div class="queued-items" style="display:none;">
 			 <span i18n:translate=''>
 				 There are <span class="queued-items-number"
-					   tal:content='python: num_tasks'
-					   i18n:name='num'/> jobs in queue for the creation of new Analysis Requests
+								 i18n:name='num'></span> jobs in queue for the creation of new Analysis Requests
 			 </span>.&nbsp;
 			 <a href='' i18n:translate='' class="button">Refresh</a>
 		 </div>

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -2610,7 +2610,7 @@ function AnalysisRequestAddByCol() {
                 {
                     type: "POST",
                     dataType: "json",
-                    url: window.location.href.split("/portal_factory")[0] + "/analysisrequest_submit",
+                    url: window.location.href.split("/portal_factory")[0] + "/analysisrequest_submit_async",
                     data: request_data,
                     success: function (data) {
                         /*

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -6,6 +6,7 @@
 function SiteView() {
 
     var that = this;
+    var pause_spinner = false;
 
     that.load = function() {
 
@@ -363,7 +364,9 @@ function SiteView() {
             counter++;
             setTimeout(function () {
                 if (counter > 0) {
-                    spinner.show('fast');
+                    if (!pause_spinner) {
+                        spinner.show('fast');
+                    }
                 }
             }, 500);
         });
@@ -383,6 +386,13 @@ function SiteView() {
             stop_spinner();
             window.bika.lims.log("Error at " + settings.url + ": " + thrownError);
         });
+    }
+
+    that.pauseSpinner = function() {
+        pause_spinner = true;
+    }
+    that.resumeSpinner = function() {
+        pause_spinner = false;
     }
 
     function portalAlert(html) {

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1380,4 +1380,19 @@ table.analysisrequest.add {}
         margin-top: -15px;
         width: inherit;
         text-align:center; }
+
+.queued-items {
+    background: #fff9ee url(&dtml-portal_url;/++resource++bika.lims.images/exclamation2_big.png) no-repeat scroll 15px center / 24px auto;
+    border-radius: 5px;
+    font-size: 1.1em;
+    margin-top: 10px;
+    padding: 15px 0 15px 48px;
+}
+.queued-items > a {
+    background-color: #436976;
+    border-radius: 5px;
+    font-size: 0.85em;
+    padding: 4px 10px;
+}
+
 </dtml-with>

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name='bika.lims',
           'z3c.jbot',
           'plone.resource',
           'CairoSVG==1.0.20',
+          'collective.taskqueue',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
The creation time of an Analysis Request with ~180 analyses takes ~1 minute aprox (see #237). With the aim to improve the user experience, this Pull Request creates Analysis Requests asynchronously when the total number of Analysis requested is >= 50. Thus, when the user clicks the button "Save" from the AR Add form, he/she is redirected almost immediately to the Analysis Requests list. An informative message is displayed. If another AR creation job is added, an informative message will appear automatically at the top of the list, prompting the user to Refresh the page.

[collective.taskqueue](https://github.com/collective/collective.taskqueue) has been used to achieve this functionality. The name of the queue for AR creation is `ar-create`. To activate the asynchronous creation of Analysis Requests, the following snippet needs to be added in buildout.cfg:

```
zope-conf-additional =
    %import collective.taskqueue
    <taskqueue>
    queue ar-create
    </taskqueue>
    <taskqueue-server>
    queue ar-create
    </taskqueue-server>
```

Auto notification of jobs in queue:

![async](https://user-images.githubusercontent.com/832627/29975739-c4a208a4-8f37-11e7-926a-9eac27aa9621.png)
