### PR TITLE
NMRL-399 ZeroDivisionError: integer division or modulo by zero when calculating progress

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -855,7 +855,9 @@ class AnalysisRequestsView(BikaListingView):
                 num_submitted = num_total - num_verified - num_wo_results
         num_steps_total = num_total * 2
         num_steps = (num_verified * 2) + (num_submitted)
-        progress_perc = (num_steps * 100) / num_steps_total
+        progress_perc = 0
+        if num_steps > 0 and num_steps_total > 0:
+            progress_perc = (num_steps * 100) / num_steps_total
         progress = '<div class="progress-bar-container">' + \
                    '<div class="progress-bar" style="width:{0}%"></div>' + \
                    '<div class="progress-perc">{0}%</div></div>'


### PR DESCRIPTION
This error was thrown in an Analysis Request list:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.analysisrequests, line 1114, in __call__
  Module bika.lims.browser.bika_listing, line 871, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 16ef82f28703d31bb8a931cb8bb83d3a.py, line 499, in render
  Module d3f52dd11125b8f9d626501acb25dc18.py, line 1172, in render_master
  Module d3f52dd11125b8f9d626501acb25dc18.py, line 484, in render_content
  Module 16ef82f28703d31bb8a931cb8bb83d3a.py, line 429, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1332, in contents_table
  Module bika.lims.browser.bika_listing, line 1426, in __init__
  Module bika.health.browser.analysisrequests.view, line 44, in folderitems
  Module bika.lims.browser.analysisrequest.analysisrequests, line 804, in folderitems
  Module bika.lims.browser.bika_listing, line 1062, in folderitems
  Module bika.health.browser.analysisrequests.view, line 48, in folderitem
  Module bika.lims.browser.analysisrequest.analysisrequests, line 856, in folderitem
ZeroDivisionError: integer division or modulo by zero
```
An Analysis Request with no analyses assigned is presumably the root reason of this error. This Pull Request fixes the error, but a better solution to be considered is to not allow the removal of all analyses from a given Analysis Request (Manage Analyses view).