### PR TITLE
NMRL-396 Search using Client not working in Add Analyses (Worksheet)

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -86,13 +86,14 @@ function WorksheetAddAnalysesView() {
             var filter_indexes = ['getCategoryTitle', 'Title', 'getClientTitle'];
             var field_set = $(this).parent('fieldset');
             for (var i=0; i<filter_indexes.length; i++) {
-                var field_name = form_id+"_"+filter_indexes[i];
+                var idx_name = filter_indexes[i];
+                var field_name = form_id+"_"+idx_name;
                 var element = $(field_set).find('[name="'+field_name+'"]');
                 var value = $(element).val();
                 if (value == undefined || value == null || value == 'any') {
                     continue;
                 }
-                params[field_name] = value;
+                params[idx_name] = value;
             }
             // Add other fields required from bikalisting form
             params['form_id'] = form_id;

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -78,50 +78,42 @@ function WorksheetAddAnalysesView() {
         $('.ws-analyses-search-button').live('click', function (event) {
             // in this context we already know there is only one bika-listing-form
             var form_id = "list";
-            var form = $("#list");
+            var form = $('form[id="'+form_id+'"]');
+            var params = {};
 
-            // request new table content by re-routing bika_listing_table form submit
-            $(form).append("<input type='hidden' name='table_only' value='" + form_id + "'>");
             // dropdowns are printed in ../templates/worksheet_add_analyses.pt
             // We add <formid>_<index>=<value>, which are checked in bika_listing.py
             var filter_indexes = ['getCategoryTitle', 'Title', 'getClientTitle'];
-            var i, fi;
-            for (i = 0; i < filter_indexes.length; i++) {
-                fi = form_id + "_" + filter_indexes[i];
-                var value = $("[name='" + fi + "']").val();
+            var field_set = $(this).parent('fieldset');
+            for (var i=0; i<filter_indexes.length; i++) {
+                var field_name = form_id+"_"+filter_indexes[i];
+                var element = $(field_set).find('[name="'+field_name+'"]');
+                var value = $(element).val();
                 if (value == undefined || value == null || value == 'any') {
-                    $("#list > [name='" + fi + "']").remove();
-                    $.query.REMOVE(fi);
+                    continue;
                 }
-                else {
-                    $(form).append("<input type='hidden' name='" + fi + "' value='" + value + "'>");
-                    $.query.SET(fi, value);
+                params[field_name] = value;
+            }
+            // Add other fields required from bikalisting form
+            params['form_id'] = form_id;
+            params['table_only'] = form_id;
+            params['portal_type'] = 'Analysis';
+            params['submitted'] = '1';
+            var base_fields = ['_authenticator', 'view_url', 'list_sort_on', 'list_sort_order'];
+            for (var i=0; i<base_fields.length; i++) {
+                var field_name = base_fields[i];
+                var field = $(form).find('input[name="'+field_name+'"]');
+                var value = $(field).val();
+                if (value == undefined || value == null) {
+                    continue;
                 }
+                params[field_name] = value;
             }
 
-            var options = {
-                target: $('.bika-listing-table'),
-                replaceTarget: true,
-                data: form.formToArray(),
-                success: function () {
-                    // Reload bika listing transitions watchers
-                    window.bika.lims.BikaListingTableView.load();
-                }
-            }
-            var url = window.location.href.split("?")[0].split("/add_analyses")[0];
-            url = url + "/add_analyses" + $.query.toString();
-            window.history.replaceState({}, window.document.title, url);
-
-            var stored_form_action = $(form).attr("action");
-            $(form).attr("action", window.location.href);
-            form.ajaxSubmit(options);
-
-            for (i = 0; i < filter_indexes.length; i++) {
-                fi = form_id + "_" + filter_indexes[i];
-                $("#list > [name='" + fi + "']").remove();
-            }
-            $(form).attr("action", stored_form_action);
-            $("[name='table_only']").remove();
+            $.post(window.location.href, params).done(function(data) {
+                $(form).find('.bika-listing-table-container').html(data);
+                window.bika.lims.BikaListingTableView.load();
+            });
 
             return false;
         });

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -128,22 +128,22 @@ class AddAnalysesView(BikaListingView):
                     self.request.RESPONSE.redirect(self.context.absolute_url() +
                                                    "/add_analyses")
             elif (
-                'list_getCategoryTitle' in form or
-                'list_Title' in form or
-                'list_getClientTitle' in form
+                'getCategoryTitle' in form or
+                'Title' in form or
+                'getClientTitle' in form
                     ):
                 # Apply filter elements
                 # Note that the name of those fields is '..Title', but we
                 # are getting their UID.
-                category = form.get('list_getCategoryTitle', '')
+                category = form.get('getCategoryTitle', '')
                 if category:
                     self.contentFilter['getCategoryUID'] = category
 
-                service = form.get('list_Title', '')
+                service = form.get('Title', '')
                 if service:
                     self.contentFilter['getServiceUID'] = service
 
-                client = form.get('list_getClientTitle', '')
+                client = form.get('getClientTitle', '')
                 if client:
                     self.contentFilter['getClientUID'] = client
 


### PR DESCRIPTION
The problem was that using the form id as the prefix in the criteria was making bika_listing to add `getClientTitle` as a filter_index, cause it was previously defined in `self.columns`:

https://github.com/naralabs/bika.lims/blob/92d95015beb4bd39df679a079bfbbe31a949cf60/bika/lims/browser/bika_listing.py#L673-L678

so an `And` clause was automatically added in accordance then:

https://github.com/naralabs/bika.lims/blob/92d95015beb4bd39df679a079bfbbe31a949cf60/bika/lims/browser/bika_listing.py#L684-L696

This resulted in bika_listing generating an AdvancedQuery that included the `contentFilter` initially set in `add_analyses.py`:

https://github.com/naralabs/bika.lims/blob/92d95015beb4bd39df679a079bfbbe31a949cf60/bika/lims/browser/worksheet/views/add_analyses.py#L130-L148

**, but also with an `And` clause for `getClientTitle`**: 

https://github.com/naralabs/bika.lims/blob/92d95015beb4bd39df679a079bfbbe31a949cf60/bika/lims/browser/bika_listing.py#L1087-L1102

The problem was that the value for `getClientTitle` was the UID actually, so the the query did not return any value (there was no Analysis in the catalog with a value for `getClientTitle` index equal to the uid passed in).

This Pull Request is a quick fix. We should consider to refactor/revisit the filtering machinery used for bika_listing. Is sometimes very confusing and the chance of error is too high if the dev has no deep knowledge about its internals.

