### PR TITLE
Sanitize tool

### DIFF
--- a/bika/lims/configure.zcml
+++ b/bika/lims/configure.zcml
@@ -31,6 +31,7 @@
   <include package=".exportimport" />
   <include package=".jsonapi" />
   <include package=".locales" />
+  <include package=".databasesanitize" />
   <include package=".monkey" />
   <include package=".search" />
   <include package=".subscribers" />

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -32,6 +32,14 @@ class Analysis(AbstractRoutineAnalysis):
             return sample
 
     @security.public
+    def getClientSampleID(self):
+        """Used to populate catalog values.
+        """
+        sample = self.getSample()
+        if sample:
+            return sample.getClientSampleID()
+
+    @security.public
     def getSiblings(self):
         """Returns the list of analyses of the Analysis Request to which this
         analysis belongs to, but with the current analysis excluded

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -32,14 +32,6 @@ class Analysis(AbstractRoutineAnalysis):
             return sample
 
     @security.public
-    def getClientSampleID(self):
-        """Used to populate catalog values.
-        """
-        sample = self.getSample()
-        if sample:
-            return sample.getClientSampleID()
-
-    @security.public
     def getSiblings(self):
         """Returns the list of analyses of the Analysis Request to which this
         analysis belongs to, but with the current analysis excluded

--- a/bika/lims/databasesanitize/analyses.py
+++ b/bika/lims/databasesanitize/analyses.py
@@ -17,14 +17,9 @@ def analyses_creation_date_recover():
     """
 
     ar_catalog = get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
-    start = DateTime('2016/06/24 01:00:00.999999 GMT+0')
-    end = DateTime('2017/06/26 23:59:59.999999 GMT+0')
-    date_range_query = {'query': (start, end), 'range': 'min:max'}
     ans_catalog = get_tool(CATALOG_ANALYSIS_LISTING)
     # Getting all analysis requests to walk through
-    ar_brains = ar_catalog({
-        "created": date_range_query,
-    })
+    ar_brains = ar_catalog()
     total_ars = len(ar_brains)
     total_iterated = 0
     logger.info("Analysis Requests to walk over: {}".format(total_ars))

--- a/bika/lims/databasesanitize/configure.zcml
+++ b/bika/lims/databasesanitize/configure.zcml
@@ -12,5 +12,20 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <browser:page
+      for="*"
+      name="async_analyses_creation_date_recover"
+      class="bika.lims.databasesanitize.controller_view.AsyncAnalysesCreationDateRecover"
+      permission="cmf.ModifyPortalContent"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+    <browser:page
+      for="*"
+      name="queued_sanitation_tasks"
+      class="bika.lims.databasesanitize.controller_view.QueuedSanitationTasksCount"
+      permission="cmf.ModifyPortalContent"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
 
 </configure>

--- a/bika/lims/databasesanitize/configure.zcml
+++ b/bika/lims/databasesanitize/configure.zcml
@@ -14,8 +14,8 @@
 
     <browser:page
       for="*"
-      name="async_analyses_creation_date_recover"
-      class="bika.lims.databasesanitize.controller_view.AsyncAnalysesCreationDateRecover"
+      name="analyses_creation_date_recover"
+      class="bika.lims.databasesanitize.controller_view.AnalysesCreationDateRecover"
       permission="cmf.ModifyPortalContent"
       layer="bika.lims.interfaces.IBikaLIMS"
     />

--- a/bika/lims/databasesanitize/configure.zcml
+++ b/bika/lims/databasesanitize/configure.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="bika">
+
+    <browser:page
+      for="*"
+      name="sanitize_action"
+      class="bika.lims.databasesanitize.controller_view.ControllerView"
+      permission="cmf.ModifyPortalContent"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+
+</configure>

--- a/bika/lims/databasesanitize/controller_view.py
+++ b/bika/lims/databasesanitize/controller_view.py
@@ -27,7 +27,7 @@ class ControllerView(BrowserView):
             self.sanitize_analyses_creation_date()
         return self.template()
 
-    def sanitize_analyses_creation(self):
+    def sanitize_analyses_creation_date(self):
             logger.info("Starting sanitation process 'Analyses creation "
                         "date recover'...")
             # Only load asynchronously if queue sanitation-tasks is available

--- a/bika/lims/databasesanitize/controller_view.py
+++ b/bika/lims/databasesanitize/controller_view.py
@@ -1,6 +1,12 @@
+import json
+
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims.browser import BrowserView
+from collective.taskqueue.interfaces import ITaskQueue
+from plone.protect import CheckAuthenticator
+from zope.component import queryUtility
+
 from bika.lims import logger
+from bika.lims.browser import BrowserView
 from bika.lims.databasesanitize.analyses import analyses_creation_date_recover
 
 
@@ -15,8 +21,43 @@ class ControllerView(BrowserView):
         if self.request.form.get('analysis_date', '0') == '1':
             logger.info("Starting sanitation process 'Analyses creation "
                         "date recover'...")
-            analyses_creation_date_recover()
+            # Only load asynchronously if queue sanitation-tasks is available
+            task_queue = queryUtility(ITaskQueue, name='sanitation-tasks')
+            if task_queue is None:
+                # sanitation-tasks queue not registered. Proceed synchronously
+                logger.info("SYNC sanitation process started...")
+                task_manager = AsyncAnalysesCreationDateRecover()
+                task_manager()
+            else:
+                # sanitation-tasks queue registered, create asynchronously
+                logger.info("[A]SYNC sanitation process started...")
+                path = self.request.PATH_INFO
+                path = path.replace(
+                    'sanitize_action', 'async_analyses_creation_date_recover')
+                task_queue.add(path, method='POST')
+                msg = 'One job added to the sanitation process queue'
+                self.context.plone_utils.addPortalMessage(msg, 'info')
 
         return self.template()
 
 
+class AsyncAnalysesCreationDateRecover():
+    """
+    This class manages the creation of async tasks.
+    """
+
+    def __call__(self):
+        analyses_creation_date_recover()
+        return json.dumps({'success': 'With taskqueue'})
+
+
+class QueuedSanitationTasksCount(BrowserView):
+
+    def __call__(self):
+        """
+        Returns the number of tasks in the sanitation-tasks queue
+        """
+        CheckAuthenticator(self.request.form)
+        task_queue = queryUtility(ITaskQueue, name='sanitation-tasks')
+        count = len(task_queue) if task_queue is not None else 0
+        return json.dumps({'count': count})

--- a/bika/lims/databasesanitize/controller_view.py
+++ b/bika/lims/databasesanitize/controller_view.py
@@ -1,0 +1,22 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims.browser import BrowserView
+from bika.lims import logger
+from bika.lims.databasesanitize.analyses import analyses_creation_date_recover
+
+
+class ControllerView(BrowserView):
+    """
+    This class is the controller for the sanitize view. Sanitize view
+    """
+    template = ViewPageTemplateFile("templates/main_template.pt")
+
+    def __call__(self):
+        # Need to generate a PDF with the stickers?
+        if self.request.form.get('analysis_date', '0') == '1':
+            logger.info("Starting sanitation process 'Analyses creation "
+                        "date recover'...")
+            analyses_creation_date_recover()
+
+        return self.template()
+
+

--- a/bika/lims/databasesanitize/templates/main_template.pt
+++ b/bika/lims/databasesanitize/templates/main_template.pt
@@ -1,0 +1,28 @@
+<form method="post"
+      action="sanitize_action">
+
+    <div id="progress_bar">
+        <progress value="0" max="100"></progress>
+    </div>
+
+    <div>
+        <p> Select the tasks to carry on: </p>
+            <p>
+                <label>
+                    <input type="checkbox" name="analysis_date"
+                           value="1">
+                    Check created date value for Analyses. Some analyses has
+                    a wrong value due to old versions of Bika. Those
+                    analyses have the creation time of their Analysis
+                    Service. This task checks all analyses and their
+                    Analysis Request creation date, if the analysis creation
+                    date is older than the Analysis Request one, the task
+                    will set the Analysis creation date with the one stored
+                    in the request.
+                </label>
+            </p>
+    </div>
+
+    <p><button>Start</button></p>
+
+</form>

--- a/bika/lims/databasesanitize/templates/main_template.pt
+++ b/bika/lims/databasesanitize/templates/main_template.pt
@@ -9,7 +9,8 @@
         <p> Select the tasks to carry on: </p>
             <p>
                 <label>
-                    <input type="checkbox" name="analysis_date"
+                    <input type="checkbox"
+                           name="sanitize_analyses_creation_date"
                            value="1">
                     Check created date value for Analyses. Some analyses has
                     a wrong value due to old versions of Bika. Those
@@ -23,6 +24,8 @@
             </p>
     </div>
 
-    <p><button>Start</button></p>
+    <p>
+        <input type="submit" id="submit" name="submit" value="Submit">
+    </p>
 
 </form>


### PR DESCRIPTION
- Due to an issue in a version of Bika, some analyses had a wrong creation date. The creation date was the same as their service creation date.

Go to "**/sanitize_action** " in order to run the script.

To use this fix you must add tho following lines in buildout.cfg:

```
egg=
...
collective.taskqueue
...
```

and the following lines under [instance] section

```
zope-conf-additional =
    %import collective.taskqueue
    <taskqueue>
    queue sanitation-tasks
    </taskqueue>
    <taskqueue-server>
    queue sanitation-tasks
    </taskqueue-server>

```
