### PR TITLE
NMRL-401 Unable to reinstate cancelled ARs

### DIFF
--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -289,12 +289,14 @@ def isTransitionAllowed(instance, transition_id, active_only=True):
     :returns: True if transition can be performed
     :rtype: bool
     """
-    #TODO Workflow to allow reinstate transition to be performed
-    inactive_transitions = ['reinstate',]
-
-    if transition_id not in inactive_transitions and \
-            active_only and not isBasicTransitionAllowed(instance):
-        return False
+    # If the instance is not active, cancellation and inactive workflows have
+    # priority over the rest of workflows associated to the object, so only
+    # allow to transition if the transition_id belongs to any of these two
+    # workflows and dismiss the rest
+    if not isActive(instance):
+        inactive_transitions = ['reinstate', 'activate']
+        if transition_id not in inactive_transitions:
+            return False
 
     wftool = getToolByName(instance, "portal_workflow")
     chain = wftool.getChainFor(instance)

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -289,7 +289,11 @@ def isTransitionAllowed(instance, transition_id, active_only=True):
     :returns: True if transition can be performed
     :rtype: bool
     """
-    if active_only and not isBasicTransitionAllowed(instance):
+    #TODO Workflow to allow reinstate transition to be performed
+    inactive_transitions = ['reinstate',]
+
+    if transition_id not in inactive_transitions and \
+            active_only and not isBasicTransitionAllowed(instance):
         return False
 
     wftool = getToolByName(instance, "portal_workflow")


### PR DESCRIPTION
**For some reason, #249 was not merged into wip**

Although the "reinstate" action was appearing in the workflow_action selection list, the object was not transitioned. The reason was because of the `active_only` param from `isTransitionAllowed` (by default, `True`), making the function to always return `False`.