### PR TITLE
NMRL-402 Client contacts cannot see ARs if department filtering enabled

### DIFF
--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -146,6 +146,9 @@ class ContactLoginDetailsView(BrowserView):
         if userid:
             try:
                 self.context.setUser(userid)
+                # If we are linking Client Contact, let it see the Client
+                if self.context.aq_parent.portal_type == 'Client':
+                    self.context.aq_parent.manage_setLocalRoles(self.context.getUsername(), ['Owner', ])
                 self.add_status_message(_("User linked to this Contact"), "info")
             except ValueError, e:
                 self.add_status_message(e, "error")

--- a/bika/lims/exportimport/setupdata/__init__.py
+++ b/bika/lims/exportimport/setupdata/__init__.py
@@ -590,6 +590,7 @@ class Client_Contacts(WorksheetImporter):
                 except Exception as msg:
                     logger.info("Error adding user (%s): %s" % (msg, username))
                 contact.aq_parent.manage_setLocalRoles(row['Username'], ['Owner', ])
+                contact.reindexObject()
                 # add user to Clients group
                 group = portal_groups.getGroupById('Clients')
                 group.addMember(username)

--- a/bika/lims/subscribers/dep_cookie.py
+++ b/bika/lims/subscribers/dep_cookie.py
@@ -32,21 +32,25 @@ def SetDepartmentCookies(event):
                                 getUsername=username)
             if not brain:
                 # It is possible that current user is created by Plone ZMI and
-                # it is not a LabContact. In this case we will just disable
-                # department filtering.
-                logger.warn("No lab Contact found... Log in with Plone user. "
+                # it is not a LabContact. We disable filtering by department because
+                # it can be Client Contact. Also we log it as a warning message in case
+                # it is not a Client Contact but a Zope User.
+                logger.warn("No lab Contact found... Plone user or Client Contact logged in. "
                             + username)
-                response.setCookie('filter_by_department_info', None,
-                                   path='/', max_age=0)
-                response.setCookie('dep_filter_disabled', None,
-                                   path='/', max_age=0)
-                return
-            lab_con = brain[0].getObject()
-            if lab_con.getDefaultDepartment():
-                dep_for_cookie=lab_con.getDefaultDepartment()
+                deps = context.portal_catalog(portal_type='Department', sort_on='sortable_title',
+                                              sort_order='ascending',
+                                              inactive_state='active')
+                for dep in deps:
+                    dep_for_cookie += dep.UID + ','
+                response.setCookie('dep_filter_disabled', None, path='/', max_age=24 * 3600)
             else:
-                deps=lab_con.getSortedDepartments()
-                dep_for_cookie=deps[0].UID() if len(deps)>0 else ''
+                lab_con = brain[0].getObject()
+                if lab_con.getDefaultDepartment():
+                    dep_for_cookie=lab_con.getDefaultDepartment()
+                else:
+                    deps=lab_con.getSortedDepartments()
+                    dep_for_cookie=deps[0].UID() if len(deps)>0 else ''
+
         response.setCookie('filter_by_department_info',dep_for_cookie,  path = '/', max_age = 24 * 3600)
     else:
         response.setCookie('filter_by_department_info',None,  path = '/', max_age = 0)


### PR DESCRIPTION
When department filtering was enabled from Bika Setup, system was setting departments for logged user by its Department list. Since Client Contact didn't have any department assigned, it failed.
With that PR, we disable filtering by department if the user is not a 'LabContact'.

**#TODO**
While loading AR listing view, there is an AJAX call to "<site_url>/analysisrequests/queued_ars" page. It fails due to Privileges of Client Contact. Related lines:

https://github.com/naralabs/bika.lims/blob/wip/bika/lims/browser/analysisrequest/templates/analysisrequests.pt#L79

https://github.com/naralabs/bika.lims/blob/wip/bika/lims/browser/analysisrequest/analysisrequests.py#L1146

 