### PR TITLE
NDEV-92 Restrictions for linking a client contact to Plone user

### DIFF
--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -92,10 +92,11 @@ class ContactLoginDetailsView(BrowserView):
         }
 
     def linkable_users(self):
-        """Search Plone users which are not linked to a contact
+        """Search Plone users which are not linked to a contact or lab contact
         """
         users = api.user.get_users()
-        expected_groups = {'AuthenticatedUsers', 'Clients'}
+        # expected groups for client contacts
+        client_contact_groups = {'AuthenticatedUsers', 'Clients'}
         out = []
         for user in users:
             userid = user.getId()
@@ -105,14 +106,16 @@ class ContactLoginDetailsView(BrowserView):
             labcontact = LabContact.getContactByUsername(userid)
             if contact or labcontact:
                 continue
-            # Checking Plone user belongs to Client group only. Otherwise,
-            # weird things could happen (a client contact assigned to a user
-            # with labman privileges, different contacts from different
-            # clients assigned to the same user, etc.)
-            user_groups = user.getGroups()
-            comparison = expected_groups.symmetric_difference(set(user_groups))
-            if comparison:
-                continue
+            if self.is_contact():
+                # Checking Plone user belongs to Client group only. Otherwise,
+                # weird things could happen (a client contact assigned to a
+                # user with labman privileges, different contacts from
+                # different clients assigned to the same user, etc.)
+                user_groups = user.getGroups()
+                comparison = client_contact_groups.symmetric_difference(
+                    set(user_groups))
+                if comparison:
+                    continue
             userdata = {
                 "userid": user.getId(),
                 "email": user.getProperty("email"),

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -96,7 +96,7 @@ class ContactLoginDetailsView(BrowserView):
         """Search Plone users which are not linked to a contact
         """
         users = api.user.get_users()
-
+        expected_groups = {'AuthenticatedUsers', 'Clients'}
         out = []
         for user in users:
             userid = user.getId()
@@ -106,7 +106,14 @@ class ContactLoginDetailsView(BrowserView):
             labcontact = LabContact.getContactByUsername(userid)
             if contact or labcontact:
                 continue
-
+            # Checking Plone user belongs to Client group only. Otherwise,
+            # weird things could happen (a client contact assigned to a user
+            # with labman privileges, different contacts from different
+            # clients assigned to the same user, etc.)
+            user_groups = user.getGroups()
+            comparison = expected_groups.symmetric_difference(set(user_groups))
+            if comparison:
+                continue
             userdata = {
                 "userid": user.getId(),
                 "email": user.getProperty("email"),

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -6,22 +6,21 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 import re
-
 from Acquisition import aq_base
 
+import transaction
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
 from plone import api
 from plone.protect import CheckAuthenticator
 
 from bika.lims import PMF
+from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.browser import BrowserView
 from bika.lims.content.contact import Contact
 from bika.lims.content.labcontact import LabContact
-from bika.lims import bikaMessageFactory as _
 
 
 class ContactLoginDetailsView(BrowserView):
@@ -213,7 +212,14 @@ class ContactLoginDetailsView(BrowserView):
             return error('password', PMF("Passwords do not match."))
 
         if len(password) < 5:
-            return error('password', PMF("Passwords must contain at least 5 letters."))
+            return error('password', PMF("Passwords must contain at least 5 "
+                                         "characters."))
+        users = api.user.get_users()
+        for user in users:
+            if user.getId() == username:
+                msg = "Username {} already exists, please, choose " \
+                      "another one.".format(username)
+                return error(None, msg)
 
         try:
             reg_tool.addMember(username,
@@ -248,17 +254,14 @@ class ContactLoginDetailsView(BrowserView):
                 group = self.portal_groups.getGroupById(group)
                 group.addMember(username)
 
-        contact.reindexObject()
-
-        if properties.validate_email or self.request.get('mail_me', 0):
+        if self.request.get('mail_me', 0):
             try:
                 reg_tool.registeredNotify(username)
             except:
-                import transaction
                 transaction.abort()
                 return error(
                     None, PMF("SMTP server disconnected."))
-
+        contact.reindexObject()
         message = PMF("Member registered.")
         self.context.plone_utils.addPortalMessage(message, 'info')
         return self.template()

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -147,6 +147,8 @@
                         batchformkeys python:['_authenticator'];">
 
             <legend i18n:translate="">Link an existing User</legend>
+            <p i18n:translate="">Only existing users in "Client" group will
+            be displayed.</p>
             <form id="user_search_form"
                   method="post">
 
@@ -158,7 +160,8 @@
                         <tr>
                             <th colspan="4" class="nosort">
                                 <input class="quickSearch" type="text" name="searchstring" value="" tal:attributes="value view/searchstring">
-                                <input type="submit" class="searchButton" name="search_button" value="Suche">
+                                <input type="submit" class="searchButton"
+                                       name="search_button" value="Search">
                             </th>
                         </tr>
                         <tr>

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -149,7 +149,7 @@
             <legend i18n:translate="">Link an existing User</legend>
             <p tal:condition="view/is_contact"
                i18n:translate="">
-                Only existing users in "Client" group will be displayed.
+                Only existing users in "Client" group are displayed.
             </p>
             <form id="user_search_form"
                   method="post">

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -147,8 +147,10 @@
                         batchformkeys python:['_authenticator'];">
 
             <legend i18n:translate="">Link an existing User</legend>
-            <p i18n:translate="">Only existing users in "Client" group will
-            be displayed.</p>
+            <p tal:condition="view/is_contact"
+               i18n:translate="">
+                Only existing users in "Client" group will be displayed.
+            </p>
             <form id="user_search_form"
                   method="post">
 


### PR DESCRIPTION
This PR does:
- The system doesn't send an email after contact creation. This was failing and it is not priority.
- In Client Contacts, it only shows the Plone contacts available to be linked if they are in both groups 'AuthenticatedUsers', 'Clients'.
- In Client Contacts, there is displayed a paragraph warning the user that "Only existing users in "Client" group will be displayed."