### PR TITLE
NDEV-94 Error when submitting duplicate analyses

### DIFF
--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -19,6 +19,7 @@ from bika.lims.content.abstractanalysis import AbstractAnalysis
 from bika.lims.content.abstractanalysis import schema
 from bika.lims.interfaces import IAnalysis, IRoutineAnalysis, \
     ISamplePrepWorkflow
+from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.workflow import getTransitionDate
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import isBasicTransitionAllowed
@@ -113,7 +114,7 @@ schema = schema.copy() + Schema((
 
 
 class AbstractRoutineAnalysis(AbstractAnalysis):
-    implements(IAnalysis, IRoutineAnalysis, ISamplePrepWorkflow)
+    implements(IAnalysis, IRequestAnalysis, IRoutineAnalysis, ISamplePrepWorkflow)
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema
@@ -142,6 +143,17 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         ar = self.getRequest()
         if ar:
             return ar.UID()
+
+    @security.public
+    def getRequestURL(self):
+        """Returns the url path of the Analysis Request object this analysis
+        belongs to. Returns None if there is no Request assigned.
+        :return: the Analysis Request URL path this analysis belongs to
+        :rtype: str
+        """
+        request = self.getRequest()
+        if request:
+            return request.absolute_url_path()
 
     @security.public
     def getClientTitle(self):
@@ -266,28 +278,25 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
             return duetime
 
     @security.public
+    @deprecated("[1709] Use getRequestID instead")
     def getAnalysisRequestTitle(self):
         """This is a catalog metadata column
         """
-        request = self.getRequest()
-        if request:
-            return request.Title()
+        return self.getRequestID()
 
     @security.public
+    @deprecated("[1709] Use getRequestUID instead")
     def getAnalysisRequestUID(self):
         """This method is used to populate catalog values
         """
-        request = self.getRequest()
-        if request:
-            return request.UID()
+        return self.getRequestUID()
 
     @security.public
+    @deprecated("[1709] Use getRequestURL instead")
     def getAnalysisRequestURL(self):
         """This is a catalog metadata column
         """
-        request = self.getRequest()
-        if request:
-            return request.absolute_url_path()
+        return self.getRequestURL()
 
     @security.public
     def getSampleTypeUID(self):

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -24,6 +24,8 @@ from bika.lims.config import *
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.idserver import renameAfterCreation
+from bika.lims.interfaces import IDuplicateAnalysis
+from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces import IWorksheet
 from bika.lims.permissions import EditWorksheet, ManageWorksheets
 from bika.lims.permissions import Verify as VerifyPermission
@@ -641,10 +643,29 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         analyses = self.getAnalyses()
         return [a for a in analyses if a.portal_type in qc_types]
 
+    def getDuplicateAnalyses(self):
+        """Return the duplicate analyses assigned to the current worksheet
+        :return: List of DuplicateAnalysis
+        :rtype: List of IDuplicateAnalysis objects"""
+        ans = self.getAnalyses()
+        duplicates = [an for an in ans if IDuplicateAnalysis.providedBy(an)]
+        return duplicates
+
+    def getReferenceAnalyses(self):
+        """Return the reference analyses (controls) assigned to the current
+        worksheet
+        :return: List of reference analyses
+        :rtype: List of IReferenceAnalysis objects"""
+        ans = self.getAnalyses()
+        references = [an for an in ans if IReferenceAnalysis.providedBy(an)]
+        return references
+
     def getRegularAnalyses(self):
         """
-        Return the regular analyses.
-        :returns: a list of regular analyses
+        Return the analyses assigned to the current worksheet that are directly
+        associated to an Analysis Request but are not QC analyses. This is all
+        analyses that implement IRoutineAnalysis
+        :return: List of regular analyses
         :rtype: List of ReferenceAnalysis/DuplicateAnalysis
         """
         qc_types = ['ReferenceAnalysis', 'DuplicateAnalysis']

--- a/bika/lims/interfaces/analysis.py
+++ b/bika/lims/interfaces/analysis.py
@@ -1,0 +1,71 @@
+from zope.interface import Interface
+
+class IRequestAnalysis(Interface):
+    """This adapter distinguishes analyses that have a request assigned from
+    those that do not have one. Typically, routine and duplicate analyses are
+    assigned to a request, whilst reference analyses are not"""
+
+    def getRequest():
+        """Returns the Analysis Request this analysis belongs to
+        :return: the Analysis Request this analysis belongs to
+        :rtype: IAnalysisRequest
+        """
+
+    def getRequestID():
+        """Returns the Analysis Request ID this analysis belongs to. If there
+        is no Request assigned to this analysis, returns None
+        :return: the Analysis Request ID this analysis belongs to
+        :rtype: str
+        """
+
+    def getRequestUID():
+        """Returns the Analysis Request UID this analysis belongs to. If there
+        is no Request assigned to this analysis, returns None
+        :return: the Analysis Request UID this analysis belongs to
+        :rtype: str
+        """
+
+    def getRequestURL():
+        """Returns the url path of the Analysis Request object this analysis
+        belongs to. Returns None if there is no Request assigned.
+        :return: the Analysis Request URL path this analysis belongs to
+        :rtype: str
+        """
+
+    def getClient():
+        """Returns the Client assigned to the Analysis Request this analysis
+        belongs to. Returns None if there is no Request assigned
+        :return: the Client associated to this analysis
+        :rtype: IClient"""
+
+    def getClientID():
+        """Returns the UID of the Client assigned to the Analysis Request this
+        analysis belongs to. Returns None if there is no Request nor a Client
+        assigned to this analysis
+        :return: the UID of the Client
+        :rtype: str
+        """
+
+    def getClientUID():
+        """Returns the UID of the Client assigned to the Analysis Request this
+        analysis belongs to. Returns None if there is no Request nor a Client
+        assigned to this analysis
+        :return: the UID of the Client
+        :rtype: str
+        """
+
+    def getClientTitle():
+        """Returns the name of the Client assigned to the Analysis Request this
+        analysis belongs to. Returns None if there is no Request nor a Client
+        assigned to this analysis
+        :return: the name of the Client
+        :rtype: str
+        """
+
+    def getClientURL():
+        """Returns the absolute url path of the Client assigned to the Analysis
+        Request this analysis belongs to. Returns None if there is no Request
+        nor a Client assigned to this analysis
+        :return: the url path of the Client
+        :type: str
+        """


### PR DESCRIPTION
When submitting a duplicate analysis (in a worksheet), the system throws the following error:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.worksheet.workflow, line 100, in __call__
  Module bika.lims.browser.worksheet.workflow, line 263, in submit
  Module bika.lims.workflow, line 114, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 252, in AfterTransitionEventHandler
  Module bika.lims.content.abstractroutineanalysis, line 565, in workflow_script_submit
  Module bika.lims.content.abstractroutineanalysis, line 402, in getDependents
  Module bika.lims.content.duplicateanalysis, line 82, in getSiblings
AttributeError: getRequestUID
```

The error was caused by `getSiblings` function from `DuplicateAnalysis`, cause it was retrieving all analyses associated to the worksheet w/o discarding those that are reference analyses (that do not have the function `getRequestUID`). `getSiblings` method is used to obtain other analyses that are closely related with the current one (e.g. to know which are the dependencies/dependants of the current analysis). For `DuplicateAnalysis`, getSiblings method returns all the analyses that are associated to the same analysis request, duplicates included.

Whit this Pull Request, a new interface `IRequestAnalysis` has been created too. This interface is used to distinguish between analyses that have a request assigned from those that do not have one. Thus, this interface provides the signatures for methods related with the retrival of the request associated to the analysis as well as main related info (UID, ID, URL, Client, etc.)