### PR TITLE
NDEV-96 Sorting on progress fails

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -81,6 +81,7 @@ class AnalysisRequestsView(BikaListingView):
                 'sortable': True,},
             'Progress': {
                 'title': 'Progress',
+                'sortable': False,
                 'toggle': True},
             'getRequestID': {
                 'title': _('Request ID'),


### PR DESCRIPTION
This PR only sets "progress" column as non sortable. Creating a metacolumn or index in a catalog would require to reindex the whole catalog and this is very expensive.

This PR is a quick fix for this first version. We will discuss the need of creating an upgrade step adding a index/column in the catalog later. 