### PR TITLE
NDEV-93 Checking async processes fails due to Privileges of Client Contact

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -3,31 +3,33 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from plone import api
-from Products.CMFCore.permissions import ModifyPortalContent
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims import bikaMessageFactory as _
-from bika.lims.config import PRIORITIES
-from bika.lims.utils import t
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.browser.analysisrequest.analysisrequests_filter_bar\
-    import AnalysisRequestsBikaListingFilterBar
-from bika.lims.utils import getUsers
-from bika.lims.workflow import getTransitionDate
-from bika.lims.permissions import *
-from bika.lims.permissions import Verify as VerifyPermission
-from bika.lims.utils import to_utf8, getUsers
-from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+import json
+import traceback
+
 from DateTime import DateTime
 from Products.Archetypes import PloneMessageFactory as PMF
+from Products.CMFCore.permissions import ModifyPortalContent
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from collective.taskqueue.interfaces import ITaskQueue
+from plone import api
 from plone.app.layout.globals.interfaces import IViewView
 from plone.protect import CheckAuthenticator
-from Products.CMFCore.utils import getToolByName
-from zope.interface import implements
-from collective.taskqueue.interfaces import ITaskQueue
+from plone.protect import PostOnly
 from zope.component import queryUtility
-from datetime import datetime, date
-import json
+from zope.interface import implements
+
+from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
+from bika.lims.browser.analysisrequest.analysisrequests_filter_bar \
+    import AnalysisRequestsBikaListingFilterBar
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.config import PRIORITIES
+from bika.lims.permissions import *
+from bika.lims.permissions import Verify as VerifyPermission
+from bika.lims.utils import getUsers
+from bika.lims.utils import t
 
 
 class AnalysisRequestsView(BikaListingView):
@@ -1143,7 +1145,16 @@ class QueuedAnalysisRequestsCount():
     def __call__(self):
         """Returns the number of tasks in the queue ar-create, responsible of
         creating Analysis Requests asynchronously"""
-        CheckAuthenticator(self.request.form)
+        try:
+            PostOnly(self.context.REQUEST)
+        except:
+            logger.error(traceback.format_exc())
+            return json.dumps({'count': 0})
+        try:
+            CheckAuthenticator(self.request.form)
+        except:
+            logger.error(traceback.format_exc())
+            return json.dumps({'count': 0})
         task_queue = queryUtility(ITaskQueue, name='ar-create')
         count = len(task_queue) if task_queue is not None else 0
         return json.dumps({'count': count})

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -92,7 +92,7 @@
       for="bika.lims.interfaces.IAnalysisRequestsFolder"
       name="queued_ars"
       class="bika.lims.browser.analysisrequest.QueuedAnalysisRequestsCount"
-      permission="bika.lims.ManageAnalysisRequests"
+      permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -76,8 +76,10 @@
 				var ar_queue_seconds = 1;
 				var ar_queue_max_seconds = 20;
 				function query_pending() {
-					var url = window.portal_url + "/analysisrequests/queued_ars"
-					$.get(url).done(function(data) {
+					var url = window.portal_url +
+					    "/analysisrequests/queued_ars";
+					var ac = readCookie('__ac');
+					$.post(url, {'__ac': ac}).done(function(data) {
 						var num_jobs = $.parseJSON(data);
 						var num_jobs = num_jobs['count'];
 						if (parseInt(num_jobs) > 0) {

--- a/bika/lims/databasesanitize/configure.zcml
+++ b/bika/lims/databasesanitize/configure.zcml
@@ -24,7 +24,7 @@
       for="*"
       name="queued_sanitation_tasks"
       class="bika.lims.databasesanitize.controller_view.QueuedSanitationTasksCount"
-      permission="cmf.ModifyPortalContent"
+      permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 

--- a/bika/lims/databasesanitize/controller_view.py
+++ b/bika/lims/databasesanitize/controller_view.py
@@ -1,8 +1,10 @@
 import json
+import traceback
 
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from collective.taskqueue.interfaces import ITaskQueue
 from plone.protect import CheckAuthenticator
+from plone.protect import PostOnly
 from zope.component import queryUtility
 
 from bika.lims import logger
@@ -64,7 +66,16 @@ class QueuedSanitationTasksCount(BrowserView):
         """
         Returns the number of tasks in the sanitation-tasks queue
         """
-        CheckAuthenticator(self.request.form)
+        try:
+            PostOnly(self.context.REQUEST)
+        except:
+            logger.error(traceback.format_exc())
+            return json.dumps({'count': 0})
+        try:
+            CheckAuthenticator(self.request.form)
+        except:
+            logger.error(traceback.format_exc())
+            return json.dumps({'count': 0})
         task_queue = queryUtility(ITaskQueue, name='sanitation-tasks')
         count = len(task_queue) if task_queue is not None else 0
         return json.dumps({'count': count})


### PR DESCRIPTION
Fixes in analysis requests and sanitation views.

- No permission definition in ZCML for class views used for AJAX calls, because the system returns an html response.
- Only use POST calls for these AJAX requests.
- Javascript function using POST calls in order to get queued processes, adds the authenticated token in the request.
- Some imports cleaning.

