### PR TITLE
bug/NMRL-407 ValueError in productivity report

### DIFF
--- a/bika/lims/browser/reports/productivity_dailysamplesreceived.py
+++ b/bika/lims/browser/reports/productivity_dailysamplesreceived.py
@@ -102,7 +102,6 @@ class Report(BrowserView):
             output = StringIO.StringIO()
             dw = csv.DictWriter(output, fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))
-            import pdb; pdb.set_trace()
             for row in datalines:
                 dw.writerow(row)
             report_data = output.getvalue()

--- a/bika/lims/browser/reports/productivity_dailysamplesreceived.py
+++ b/bika/lims/browser/reports/productivity_dailysamplesreceived.py
@@ -67,9 +67,10 @@ class Report(BrowserView):
                                 sample.getDateReceived(), long_format=1),
                             'DateSampled': self.ulocalized_time(
                                 ds, long_format=1),
-                            'SamplingDate': self.ulocalized_time(
-                                sd, long_format=1)
                             }
+                if self.context.bika_setup.getSamplingWorkflowEnabled():
+                    dataline['SamplingDate']= self.ulocalized_time(
+                                              sd, long_format=1)
                 datalines.append(dataline)
                 analyses_count += 1
 
@@ -101,6 +102,7 @@ class Report(BrowserView):
             output = StringIO.StringIO()
             dw = csv.DictWriter(output, fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))
+            import pdb; pdb.set_trace()
             for row in datalines:
                 dw.writerow(row)
             report_data = output.getvalue()


### PR DESCRIPTION
When generating a _Daily samples received_ report the fieldname ```SamplingDate``` is only being added to the report if the Sampling workflow is enabled. However, the sampling date data was always being added to the dataline used to generate the report. When Sampling workflow wasn't enabled this resulted in inconsistencies that crashed the report generation. 

The solution is to only add sampling date data to the dataline when ```SamplingDate``` is also added as a fieldname i.e, when sampling workflow is enabled.
