### PR TITLE
NMRL-408 Make use of adapters for SearchableText in Batches listings

### DIFF
--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -137,8 +137,6 @@ class BatchFolderContentsView(BikaListingView):
         return False
 
     def folderitems(self):
-        self.filter_indexes = None
-
         items = BikaListingView.folderitems(self)
         for x in range(len(items)):
             if 'obj' not in items[x]:

--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -367,7 +367,7 @@ class Batch(ATFolder):
         plain_text_fields = ("BatchID", "ClientBatchID")
 
         # Checking if an adapter exists. If yes, we will
-        # get plain_text_fields from adapter.
+        # get plain_text_fields from adapters.
         for name, adapter in getAdapters((self,), IBatchSearchableText):
             entries += adapter.get_plain_text_fields()
 

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -466,7 +466,7 @@ class IBatchSearchableText(Interface):
     """ Interface for BatchSearchableText """
 
     def get_plain_text_fields(self):
-        """ Returns field names as a tuple of strings"""
+        """ Returns field names as a list of strings"""
 
 class IReferenceWidgetVocabulary(Interface):
     """Return values for reference widgets in AR contexts

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -461,6 +461,12 @@ class IIdServer(Interface):
     def generate_id(self, portal_type, batch_size=None):
         """ Generate a new id for 'portal_type' """
 
+class IBatchSearchableText(Interface):
+
+    """ Interface for BatchSearchableText """
+
+    def get_plain_text_fields(self):
+        """ Returns field names as a tuple of strings"""
 
 class IReferenceWidgetVocabulary(Interface):
     """Return values for reference widgets in AR contexts


### PR DESCRIPTION
The search input in batches lists wasn't working for two reasons, first because it was disabled and second because searchable text was only working for LIMS add-on. This PR enables it again and uses adapters in order to get searchable texts from other addons.