### PR TITLE
NDEV-102 Error in Reference Widget Search

### DIFF
--- a/bika/lims/adapters/referencewidgetvocabulary.py
+++ b/bika/lims/adapters/referencewidgetvocabulary.py
@@ -62,8 +62,15 @@ class DefaultReferenceWidgetVocabulary(object):
                     fields_wo_index.append(field_name)
                     continue
                 if index.meta_type in ('ZCTextIndex'):
-                    temp_st = searchTerm + '*'
-                    criterias.append(MatchRegexp(field_name, temp_st))
+                    if searchTerm.isspace():
+                        # earchTerm != ' ' added because of
+                        # https://github.com/plone/Products.CMFPlone/issues
+                        # /1537
+                        searchTerm = ''
+                        continue
+                    else:
+                        temp_st = searchTerm + '*'
+                        criterias.append(MatchRegexp(field_name, temp_st))
                 elif index.meta_type in ('FieldIndex'):
                     criterias.append(MatchRegexp(field_name, searchTerm))
                 elif index.meta_type == 'DateIndex':


### PR DESCRIPTION
On Analysis Service Creation page, this error occurs when searching for department.

```
ERROR Zope.SiteErrorLog 1507019341.860.945047024869 http://localhost:8080/Plone/bika_setup/bika_analysisservices/referencewidget_search
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.widgets.referencewidget, line 198, in __call__
  Module bika.lims.adapters.referencewidgetvocabulary, line 83, in __call__
  Module Products.AdvancedQuery, line 88, in _evalAdvancedQuery
  Module Products.AdvancedQuery.eval, line 40, in eval
  Module Products.AdvancedQuery.eval, line 16, in _eval
  Module Products.AdvancedQuery.AdvancedQuery, line 220, in _eval
  Module Products.AdvancedQuery.AdvancedQuery, line 235, in _eval
  Module Products.AdvancedQuery.AdvancedQuery, line 84, in _eval
  Module Products.AdvancedQuery.AdvancedQuery, line 279, in _applyIndex
  Module Products.ZCTextIndex.ZCTextIndex, line 217, in _apply_index
  Module Products.ZCTextIndex.QueryParser, line 139, in parseQuery
ParseError: Query contains only common words: u' *'

```

This is caused by a zcatalog limitation that can't deal with spaces as search terms for ZCTextIndex