### PR TITLE
NDEV-79 Unknown sort_on index (getCategoryTitle) in Worksheet's Add Analyses view

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -42,11 +42,11 @@ function WorksheetAddAnalysesView() {
     that.load = function() {
 
         // search form - selecting a category fills up the service selector
-        $('[name="list_getCategoryTitle"]').live("change", function(){
-            val = $('[name="list_getCategoryTitle"]').find(":selected").val();
+        $('[name="list_FilterByCategory"]').live("change", function(){
+            val = $('[name="list_FilterByCategory"]').find(":selected").val();
             if(val == 'any'){
-                $('[name="list_Title"]').empty();
-                $('[name="list_Title"]').append("<option value='any'>"+_('Any')+"</option>");
+                $('[name="list_FilterByService"]').empty();
+                $('[name="list_FilterByService"]').append("<option value='any'>"+_('Any')+"</option>");
                 return;
             }
             $.ajax({
@@ -56,25 +56,26 @@ function WorksheetAddAnalysesView() {
                        'getCategoryUID': val},
                 dataType: "json",
                 success: function(data, textStatus, $XHR){
-                    current_service_selection = $('[name="list_Title"]').val();
-                    $('[name="list_Title"]').empty();
-                    $('[name="list_Title"]').append("<option value='any'>"+_('Any')+"</option>");
+                    current_service_selection = $('[name="list_FilterByService"]').val();
+                    $('[name="list_FilterByService"]').empty();
+                    $('[name="list_FilterByService"]').append("<option value='any'>"+_('Any')+"</option>");
                     for(i=0; i<data.length; i++){
                         if (data[i] == current_service_selection){
                             selected = 'selected="selected" ';
                         } else {
                             selected = '';
                         }
-                        $('[name="list_Title"]').append(
+                        $('[name="list_FilterByService"]').append(
                             "<option "+selected+"value='"+data[i][0]+
                             "'>"+data[i][1]+"</option>");
                     }
                 }
             });
         });
-        $('[name="list_getCategoryTitle"]').trigger("change");
+        $('[name="list_FilterByCategory"]').trigger("change");
 
-        // add_analyses analysis search is handled by bika_listing default __call__
+        // add_analyses analysis search is handled by
+        // worksheet/views/add_analyses/AddAnalysesView/__call__
         $('.ws-analyses-search-button').live('click', function (event) {
             // in this context we already know there is only one bika-listing-form
             var form_id = "list";
@@ -82,8 +83,11 @@ function WorksheetAddAnalysesView() {
             var params = {};
 
             // dropdowns are printed in ../templates/worksheet_add_analyses.pt
-            // We add <formid>_<index>=<value>, which are checked in bika_listing.py
-            var filter_indexes = ['getCategoryTitle', 'Title', 'getClientTitle'];
+            // We add <formid>_<filterby_index>=<value>, which are checked in
+            // worksheet/view/add_analyses.py/__call__, that are different
+            // from listing or catalog filters
+            var filter_indexes = ['FilterByCategory', 'FilterByService',
+                'FilterByClient'];
             var field_set = $(this).parent('fieldset');
             for (var i=0; i<filter_indexes.length; i++) {
                 var idx_name = filter_indexes[i];

--- a/bika/lims/browser/worksheet/templates/add_analyses.pt
+++ b/bika/lims/browser/worksheet/templates/add_analyses.pt
@@ -63,10 +63,10 @@
 		</td></tr></table>
 
 		<fieldset class="criteria" name="criteria" style="margin-top: 0.5em;">
-			<label tal:attributes="for string:${form_id}_getCategoryTitle"
+			<label tal:attributes="for string:${form_id}_FilterByCategory"
 				i18n:translate="">Category</label>
 			<select id="CategorySelector"
-					tal:attributes="name string:${form_id}_getCategoryTitle"
+					tal:attributes="name string:${form_id}_FilterByCategory"
 					tal:define="categories_list view/getCategories"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
@@ -79,10 +79,10 @@
 				</tal:options>
 			</select>
 
-			<label tal:attributes="for string:${form_id}_Title"
+			<label tal:attributes="for string:${form_id}_FilterByService"
 				i18n:translate="">Service</label>
 			<select id="ServiceSelector"
-					tal:attributes="name string:${form_id}_Title"
+					tal:attributes="name string:${form_id}_FilterByService"
 					tal:define="services_list view/getServices"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>
@@ -95,10 +95,10 @@
 				</tal:options>
 			</select>
 
-			<label tal:attributes="for string:${form_id}_getClientTitle"
+			<label tal:attributes="for string:${form_id}_FilterByClient"
 				i18n:translate="">Client</label>
 			<select id="ClientSelector"
-					tal:attributes="name string:${form_id}_getClientTitle"
+					tal:attributes="name string:${form_id}_FilterByClient"
 					tal:define="clients_list view/getClients"
 					class="listing-filter">
 				<option value="any" i18n:translate="">Any</option>

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -70,7 +70,7 @@ class AddAnalysesView(BikaListingView):
             'CategoryTitle': {
                 'title': _('Category'),
                 'attr': 'getCategoryTitle',
-                'index': 'getCategoryTitle'},
+                'sortable': False},
             'Title': {
                 'title': _('Analysis'),
                 'index':'getId'},
@@ -128,22 +128,22 @@ class AddAnalysesView(BikaListingView):
                     self.request.RESPONSE.redirect(self.context.absolute_url() +
                                                    "/add_analyses")
             elif (
-                'getCategoryTitle' in form or
-                'Title' in form or
-                'getClientTitle' in form
+                'FilterByCategory' in form or
+                'FilterByService' in form or
+                'FilterByClient' in form
                     ):
                 # Apply filter elements
                 # Note that the name of those fields is '..Title', but we
                 # are getting their UID.
-                category = form.get('getCategoryTitle', '')
+                category = form.get('FilterByCategory', '')
                 if category:
                     self.contentFilter['getCategoryUID'] = category
 
-                service = form.get('Title', '')
+                service = form.get('FilterByService', '')
                 if service:
                     self.contentFilter['getServiceUID'] = service
 
-                client = form.get('getClientTitle', '')
+                client = form.get('FilterByClient', '')
                 if client:
                     self.contentFilter['getClientUID'] = client
 


### PR DESCRIPTION
After clicking on a column header in order to sort the results, the list was disappearing. 

This was caused because the name of the HTML fields in the filtering bar had the same name as the filters used to sort the list after clicking in a  column header.

This PR changes the names of those HTML fields in order to avoid this problem. It also disables the filtering by Category column since there is no index for that in analyses catalog.

**Important note**: Javascript involved, requires *hard-refresh* (Ctrl+F5)