### PR TITLE
FIlter By date results submitted not working well

### DIFF
--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -29,6 +29,7 @@ _indexes_dict = {
     'getDateReceived': 'DateIndex',
     'getResultCaptureDate': 'DateIndex',
     'getDateAnalysisPublished': 'DateIndex',
+    'getDateSubmitted': 'DateIndex',
     'getClientUID': 'FieldIndex',
     'getClientTitle': 'FieldIndex',
     'getAnalyst': 'FieldIndex',

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -17,4 +17,11 @@
        handler="bika.lims.upgrade.v01_00_000.upgrade"
        profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+       title="Upgrade to Bika LIMS Evo 1.1.0"
+       source="1.0.*"
+       destination="1.1.0"
+       handler="bika.lims.upgrade.v01_01_000.upgrade"
+       profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/v01_01_000.py
+++ b/bika/lims/upgrade/v01_01_000.py
@@ -1,0 +1,38 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.config import PROJECTNAME as product
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+
+version = '1.1.0'
+profile = 'profile-{0}:default'.format(product)
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(product)
+
+    # Since this upgrade is precisely meant to establish a version regardless
+    # of the version numbering at bikalims/bika.lims, we don't want this check
+    # to be performed.
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ver_from, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
+    # Add missing getDateSubmitted Index into analyses catalog
+    ut.addIndex(
+        CATALOG_ANALYSIS_LISTING, 'getDateSubmitted', 'DateIndex')
+    ut.refreshCatalogs()
+    # Do nothing, we just only want the profile version to be 1.0.0
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
Filter wasn't working because the index was missing.

This PR adds the **getDateSubmitted** index while adding a whole upgrade step to version 1.1.0