### PR TITLE
NMRL-422 Enable "Select All" button in the Department Portlet for all users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Changed**
 
+- #278 Enable "Select All" button in the Department Portlet for all users
 - #234 Consistent implementation of Analysis Request accessors that relate to Sample
 
 **Fixed**

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -425,10 +425,10 @@ function SiteView() {
     function loadFilterByDepartment() {
         /**
         This function sets up the filter by department cookie value by chosen departments.
-        Also it does auto-submit if admin wants to enable/disable the department filtering.
+        Also when user clicks on 'Select all departments' button, enables all available departments
+        for the current user.
         */
         $('#department_filter_submit').click(function() {
-          if(!($('#admin_dep_filter_enabled').is(":checked"))) {
             var deps =[];
             $.each($("input[name^=chb_deps_]:checked"), function() {
               deps.push($(this).val());
@@ -438,26 +438,24 @@ function SiteView() {
               deps.push($('input[name^=chb_deps_]:checkbox:not(:checked):visible:first').val());
             }
             setCookie(cookiename, deps.toString());
-          }
-          window.location.reload(true);
+            window.location.reload(true);
         });
 
-        $('#admin_dep_filter_enabled').change(function() {
-            var cookiename = 'filter_by_department_info';
-            if($(this).is(":checked")) {
-                var deps=[];
-                $.each($("input[name^=chb_deps_]:checkbox"), function() {
-                  deps.push($(this).val());
-                });
-                setCookie(cookiename, deps);
-                setCookie('dep_filter_disabled','true');
-                window.location.reload(true);
-              }else{
-                setCookie('dep_filter_disabled','false');
-                window.location.reload(true);
-              }
+        $('#select_all_deps').click(function() {
+            var deps =[];
+            $.each($("input[name^=chb_deps_]"), function() {
+              deps.push($(this).val());
             });
-          loadFilterByDepartmentCookie();
+            var cookiename = 'filter_by_department_info';
+            if (deps.length===0) {
+              deps.push($('input[name^=chb_deps_]:checkbox:not(:checked):visible:first').val());
+            }
+            setCookie(cookiename, deps.toString());
+
+            window.location.reload(true);
+        });
+
+        loadFilterByDepartmentCookie();
     }
 
     function loadFilterByDepartmentCookie(){
@@ -465,7 +463,6 @@ function SiteView() {
         This function checks if the cookie 'filter_by_department_info' is
         available. If the cookie exists, do nothing, if the cookie has not been
         created yet, checks the selected department in the checkbox group and creates the cookie with the UID of the first department.
-        If cookie value "dep_filter_disabled" is true, it means the user is admin and filtering is disabled.
         */
         // Gettin the cookie
         var cookiename = 'filter_by_department_info';
@@ -474,10 +471,6 @@ function SiteView() {
         if (cookie_val === null || cookie_val===""){
             var dep_uid = $('input[name^=chb_deps_]:checkbox:visible:first').val();
             setCookie(cookiename, dep_uid);
-        }
-        var dep_filter_disabled=readCookie('dep_filter_disabled');
-        if (dep_filter_disabled=="true" || dep_filter_disabled=='"true"'){
-            $('#admin_dep_filter_enabled').prop("checked",true);
         }
     }
 

--- a/bika/lims/content/analysiscategory.py
+++ b/bika/lims/content/analysiscategory.py
@@ -19,6 +19,7 @@ from Products.CMFCore.WorkflowCore import WorkflowException
 from zope.interface import implements
 import sys
 import transaction
+from bika.lims import deprecated
 
 
 @indexer(IAnalysisCategory)

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -195,6 +195,13 @@ dl.portlet dt.portletLateAnalyses {
   color: &dtml-portletLateAnalysesTextColor;;
 }
 
+dl.portlet a.dp-select-all{
+    cursor: pointer;
+    font-weight: bold;
+    border-radius: 0.5em;
+    border: 2px solid #ccc !important;
+    padding: 3px;
+}
 /* Pretty table classes for tinyMCE
 */
 .three_column_table td {

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -35,7 +35,7 @@
             name="portletfilter_by_department"
             method="POST">
             <dd class="portletItem">
-                <a id="select_all_deps" style=" cursor: pointer; font-weight: bold; border-radius: 0.5em; border: 2px solid #ccc !important; padding: 3px;"
+                <a id="select_all_deps" class="dp-select-all"
                   tal:condition="python: len(deps)>1">Select All</a> <br><br>
                 <tal:option repeat="dep deps" tal:condition="python: len(deps)>1">
                     <ul>

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -13,7 +13,6 @@
 <tal:departments
     tal:define="portal context/portal_url/getPortalObject;
                 plone_view context/@@plone;
-                dep_disabled python:request.cookies.get('dep_filter_disabled','');
                 deps python: here.portal_catalog(portal_type='Department',sort_on='sortable_title', sort_order='ascending',
                                             inactive_state='active') if user_name=='admin' else brains[0].getObject().getSortedDepartments();
                 cookie python:request.cookies.get(
@@ -36,12 +35,8 @@
             name="portletfilter_by_department"
             method="POST">
             <dd class="portletItem">
-                <input type="checkbox"
-                       name="admin_dep_filter_enabled"
-                       id="admin_dep_filter_enabled"
-                       tal:condition= "python: user_name=='admin'"/>
-                       <label tal:condition= "python: user_name=='admin'">Select All Departments<br><br></label>
-
+                <a id="select_all_deps" style=" cursor: pointer; font-weight: bold; border-radius: 0.5em; border: 2px solid #ccc !important; padding: 3px;"
+                  tal:condition="python: len(deps)>1">Select All</a> <br><br>
                 <tal:option repeat="dep deps" tal:condition="python: len(deps)>1">
                     <ul>
                         <li tal:define="dep_name python:dep.Title if user_name=='admin' else dep.Title();
@@ -50,7 +45,7 @@
                                 tal:attributes="
                                     value python: dep_uid;
                                     name python: 'chb_deps_'+ dep_name;
-                                    checked python: 'true' if dep_disabled=='true' else 'true' if any(dep_uid in cd for cd in deps_from_cookie) else 'true' if first_dep==dep_uid else ''"/>
+                                    checked python: 'true' if any(dep_uid in cd for cd in deps_from_cookie) else 'true' if first_dep==dep_uid else ''"/>
                             <span tal:content="python: dep_name"></span>
                         </li>
                     </ul>
@@ -62,7 +57,7 @@
                     tal:condition="python: len(deps)<2"
                     tal:content="python: deps[0].Title if user_name=='admin' and deps else deps[0].Title() if deps else ''"
                     >Department</label>
-            </dd><br>
+            </dd>
             <!-- The submit form button -->
             <dd class="portletFooter">
                 <input type="button" id="department_filter_submit" value="Filter"

--- a/bika/lims/subscribers/dep_cookie.py
+++ b/bika/lims/subscribers/dep_cookie.py
@@ -26,7 +26,6 @@ def SetDepartmentCookies(event):
                     inactive_state='active')
             for dep in deps:
                 dep_for_cookie+=dep.UID+','
-            response.setCookie('dep_filter_disabled', 'true',  path = '/', max_age = 24 * 3600)
         else:
             brain = context.portal_catalog(getUsername=username)
             # It is possible that current user is created by Plone ZMI.
@@ -35,7 +34,6 @@ def SetDepartmentCookies(event):
                 logger.warn("No lab Contact found... Plone user or Client Contact logged in. "
                             + username)
                 response.setCookie('filter_by_department_info', None, path='/', max_age=0)
-                response.setCookie('dep_filter_disabled', None, path='/', max_age=0)
                 return
 
             # If it is Client Contact, enable all departments no need to filter.
@@ -45,7 +43,6 @@ def SetDepartmentCookies(event):
                                               inactive_state='active')
                 for dep in deps:
                     dep_for_cookie += dep.UID + ','
-                response.setCookie('dep_filter_disabled', None, path='/', max_age=24 * 3600)
 
             # It is a LabContact, set up departments.
             else:
@@ -58,8 +55,7 @@ def SetDepartmentCookies(event):
 
         response.setCookie('filter_by_department_info',dep_for_cookie,  path = '/', max_age = 24 * 3600)
     else:
-        response.setCookie('filter_by_department_info',None,  path = '/', max_age = 0)
-        response.setCookie('dep_filter_disabled',None,  path = '/', max_age = 0)
+        response.setCookie('filter_by_department_info',None,  path = '/', max_age=0)
 
 
 def ClearDepartmentCookies(event):
@@ -71,7 +67,6 @@ def ClearDepartmentCookies(event):
     response = request.RESPONSE
     # Voiding our special cookie on logout
     response.setCookie('filter_by_department_info',None,  path = '/', max_age = 0)
-    response.setCookie('dep_filter_disabled',None,  path = '/', max_age = 0)
 
 def find_context(request):
     """


### PR DESCRIPTION
Before, 'Select All Departments' was a checkbox, and it was enabled only for admin. Now, it is an anchor and all users with more than one department assigned will have it in Department Portlet. When user clicks on that 'button', page will be reloaded and all available departments will be chosen.